### PR TITLE
Added option for the disable bgfg algorithms from the opencv_contrib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,12 @@ set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
   SOURCE_GROUP("Header Files" FILES ${folder_header})
 
   SOURCE_GROUP("graph" FILES ${graph_source} ${graph_source})
+
+option(USE_OCV_BGFG "Should the bgfg algorithms from opencv_contrib?" ON)
+if(USE_OCV_BGFG)
+    add_definitions(-DUSE_OCV_BGFG)
+endif(USE_OCV_BGFG)
+
 # ----------------------------------------------------------------------------  
 # создаем проект
 # ----------------------------------------------------------------------------

--- a/vibe_src/BackgroundSubtract.h
+++ b/vibe_src/BackgroundSubtract.h
@@ -3,7 +3,10 @@
 
 #include "defines.h"
 #include "vibe.hpp"
+
+#if USE_OCV_BGFG
 #include <opencv2/bgsegm.hpp>
+#endif
 
 class BackgroundSubtract
 {
@@ -25,7 +28,9 @@ public:
 
 private:
 	std::unique_ptr<vibe::VIBE> m_modelVibe;
+#if USE_OCV_BGFG
 	cv::Ptr<cv::BackgroundSubtractor> m_modelOCV;
+#endif
 };
 
 #endif


### PR DESCRIPTION
Can enable or disable MOG and GMG from the sources by setting option USE_OCV_BGFG in CMake