### PR TITLE
 Fixed bug in c4 pedestrian detector 

### DIFF
--- a/Detector/BackgroundSubtract.cpp
+++ b/Detector/BackgroundSubtract.cpp
@@ -26,7 +26,7 @@ BackgroundSubtract::BackgroundSubtract(
             m_modelVibe = std::make_unique<vibe::VIBE>(m_channels, samples, pixel_neighbor, distance_threshold, matching_threshold, update_factor);
             break;
 
-#if USE_OCV_BGFG
+#ifdef USE_OCV_BGFG
         case ALG_MOG:
             m_modelOCV = cv::bgsegm::createBackgroundSubtractorMOG(100, 3, 0.7, 0);
             break;
@@ -120,7 +120,7 @@ void BackgroundSubtract::subtract(const cv::Mat& image, cv::Mat& foreground)
 	case ALG_MOG:
 	case ALG_GMG:
     case ALG_CNT:
-#if USE_OCV_BGFG
+#ifdef USE_OCV_BGFG
 		m_modelOCV->apply(GetImg(), foreground);
 		break;
 #else

--- a/Detector/BackgroundSubtract.h
+++ b/Detector/BackgroundSubtract.h
@@ -6,7 +6,7 @@
 #include "Subsense/BackgroundSubtractorSuBSENSE.h"
 #include "Subsense/BackgroundSubtractorLOBSTER.h"
 
-#if USE_OCV_BGFG
+#ifdef USE_OCV_BGFG
 #include <opencv2/bgsegm.hpp>
 #endif
 

--- a/Tracker/Ctracker.h
+++ b/Tracker/Ctracker.h
@@ -28,10 +28,6 @@ public:
     tracks_t tracks;
     void Update(const std::vector<Point_t>& detections, const regions_t& regions, cv::Mat grayFrame);
 
-#if SAVE_TRAJECTORIES
-    void WriteAllTracks();
-#endif
-
 private:
     // Use local tracking for regions between two frames
     bool m_useLocalTracking;

--- a/Tracker/Kalman.cpp
+++ b/Tracker/Kalman.cpp
@@ -183,7 +183,7 @@ void get_lin_regress_params(
     by = det_1 * (m2 * m3_y + m1 * m4_y);
 }
 
-#if USE_OCV_UKF
+#ifdef USE_OCV_UKF
 //---------------------------------------------------------------------------
 class AcceleratedModel: public cv::tracking::UkfSystemModel
 {
@@ -465,7 +465,7 @@ Point_t TKalmanFilter::GetPointPrediction()
 
         case tracking::KalmanUnscented:
         case tracking::KalmanAugmentedUnscented:
-#if USE_OCV_UKF
+#ifdef USE_OCV_UKF
             prediction = m_uncsentedKalman->predict();
 #else
             prediction = m_linearKalman->predict();
@@ -512,7 +512,7 @@ Point_t TKalmanFilter::Update(Point_t pt, bool dataCorrect)
                 break;
 
             case tracking::KalmanUnscented:
-#if USE_OCV_UKF
+#ifdef USE_OCV_UKF
                 CreateUnscented(xy0, xyv0);
 #else
                 CreateLinear(xy0, xyv0);
@@ -521,7 +521,7 @@ Point_t TKalmanFilter::Update(Point_t pt, bool dataCorrect)
                 break;
 
             case tracking::KalmanAugmentedUnscented:
-#if USE_OCV_UKF
+#ifdef USE_OCV_UKF
                 CreateAugmentedUnscented(xy0, xyv0);
 #else
                 CreateLinear(xy0, xyv0);
@@ -555,7 +555,7 @@ Point_t TKalmanFilter::Update(Point_t pt, bool dataCorrect)
 
         case tracking::KalmanUnscented:
         case tracking::KalmanAugmentedUnscented:
-#if USE_OCV_UKF
+#ifdef USE_OCV_UKF
             estimated = m_uncsentedKalman->correct(measurement);
 #else
             estimated = m_linearKalman->correct(measurement);
@@ -592,7 +592,7 @@ cv::Rect TKalmanFilter::GetRectPrediction()
 
         case tracking::KalmanUnscented:
         case tracking::KalmanAugmentedUnscented:
-#if USE_OCV_UKF
+#ifdef USE_OCV_UKF
             prediction = m_uncsentedKalman->predict();
 #else
             prediction = m_linearKalman->predict();
@@ -650,7 +650,7 @@ cv::Rect TKalmanFilter::Update(cv::Rect rect, bool dataCorrect)
                 break;
 
             case tracking::KalmanUnscented:
-#if USE_OCV_UKF
+#ifdef USE_OCV_UKF
                 CreateUnscented(rect0, rectv0);
 #else
                 CreateLinear(rect0, rectv0);
@@ -659,7 +659,7 @@ cv::Rect TKalmanFilter::Update(cv::Rect rect, bool dataCorrect)
                 break;
 
             case tracking::KalmanAugmentedUnscented:
-#if USE_OCV_UKF
+#ifdef USE_OCV_UKF
                 CreateAugmentedUnscented(rect0, rectv0);
 #else
                 CreateLinear(rect0, rectv0);
@@ -702,7 +702,7 @@ cv::Rect TKalmanFilter::Update(cv::Rect rect, bool dataCorrect)
 
         case tracking::KalmanUnscented:
         case tracking::KalmanAugmentedUnscented:
-#if USE_OCV_UKF
+#ifdef USE_OCV_UKF
             estimated = m_uncsentedKalman->correct(measurement);
 
             m_lastRectResult.x = estimated.at<track_t>(0);   //update using measurements

--- a/Tracker/Kalman.h
+++ b/Tracker/Kalman.h
@@ -4,7 +4,7 @@
 
 #include <opencv/cv.h>
 
-#if USE_OCV_UKF
+#ifdef USE_OCV_UKF
 #include <opencv2/tracking.hpp>
 #include <opencv2/tracking/kalman_filters.hpp>
 #endif
@@ -26,7 +26,7 @@ public:
 private:
     tracking::KalmanType m_type;
     std::unique_ptr<cv::KalmanFilter> m_linearKalman;
-#if USE_OCV_UKF
+#ifdef USE_OCV_UKF
     cv::Ptr<cv::tracking::UnscentedKalmanFilter> m_uncsentedKalman;
 #endif
 
@@ -44,7 +44,7 @@ private:
 
     void CreateLinear(Point_t xy0, Point_t xyv0);
     void CreateLinear(cv::Rect_<track_t> rect0, Point_t rectv0);
-#if USE_OCV_UKF
+#ifdef USE_OCV_UKF
     void CreateUnscented(Point_t xy0, Point_t xyv0);
     void CreateUnscented(cv::Rect_<track_t> rect0, Point_t rectv0);
     void CreateAugmentedUnscented(Point_t xy0, Point_t xyv0);

--- a/Tracker/track.cpp
+++ b/Tracker/track.cpp
@@ -217,7 +217,7 @@ void CTrack::RectUpdate(
     case tracking::TrackKCF:
     case tracking::TrackMIL:
     case tracking::TrackMedianFlow:
-#if USE_OCV_KCF
+#ifdef USE_OCV_KCF
         if (!dataCorrect)
         {
             cv::Size roiSize(currFrame.cols / 2, currFrame.rows / 2);
@@ -318,7 +318,7 @@ void CTrack::CreateExternalTracker()
         break;
 
     case tracking::TrackKCF:
-#if USE_OCV_KCF
+#ifdef USE_OCV_KCF
         if (!m_tracker || m_tracker.empty())
         {
             cv::TrackerKCF::Params params;
@@ -336,7 +336,7 @@ void CTrack::CreateExternalTracker()
         break;
 
     case tracking::TrackMIL:
-#if USE_OCV_KCF
+#ifdef USE_OCV_KCF
         if (!m_tracker || m_tracker.empty())
         {
             cv::TrackerMIL::Params params;
@@ -351,7 +351,7 @@ void CTrack::CreateExternalTracker()
         break;
 
     case tracking::TrackMedianFlow:
-#if USE_OCV_KCF
+#ifdef USE_OCV_KCF
         if (!m_tracker || m_tracker.empty())
         {
             cv::TrackerMedianFlow::Params params;

--- a/Tracker/track.h
+++ b/Tracker/track.h
@@ -5,7 +5,7 @@
 #include <memory>
 #include <array>
 
-#if USE_OCV_KCF
+#ifdef USE_OCV_KCF
 #include <opencv2/tracking.hpp>
 #endif
 
@@ -199,7 +199,7 @@ private:
     bool m_filterObjectSize;
 
     tracking::LostTrackType m_externalTrackerForLost;
-#if USE_OCV_KCF
+#ifdef USE_OCV_KCF
     cv::Ptr<cv::Tracker> m_tracker;
 #endif
 

--- a/pedestrians/c4-pedestrian-detector.h
+++ b/pedestrians/c4-pedestrian-detector.h
@@ -397,7 +397,7 @@ void IntImage<T>::Sobel(IntImage<REAL>& result,const bool useSqrt,const bool nor
     result.Create(nrow,ncol);
     for(int i=0; i<nrow; i++) result.p[i][0] = result.p[i][ncol-1] = 0;
     std::fill(result.p[0],result.p[0]+ncol,0.0);
-    std::fill(result.p[nrow-1],result.p[nrow-1],0.0);
+    std::fill(result.p[nrow-1],result.p[nrow-1]+ncol,0.0);
     for(int i=1; i<nrow-1; i++)
     {
         T* p1 = p[i-1];


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. error: V549 The first argument of 'fill' function is equal to the second argument.