### PR TITLE
Fixed memory leak in the Hungarian algorithm

### DIFF
--- a/Tracker/HungarianAlg/HungarianAlg.cpp
+++ b/Tracker/HungarianAlg/HungarianAlg.cpp
@@ -513,6 +513,11 @@ void AssignmentProblemSolver::assignmentsuboptimal1(assignments_t& assignment, t
 	{
 		if (!finiteValueFound)
 		{
+            /* free allocated memory */
+            free(nOfValidObservations);
+            free(nOfValidTracks);
+            free(distMatrix);
+
 			return;
 		}
 		bool repeatSteps = true;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.
Error: V773 The function was exited without releasing the 'distMatrix' pointer. A memory leak is possible.
Error: V773 The function was exited without releasing the 'nOfValidObservations' pointer. A memory leak is possible.
Error: V773 The function was exited without releasing the 'nOfValidTracks' pointer. A memory leak is possible.