### PR TITLE
Not all members of a class are initialized inside the constructor

### DIFF
--- a/Tracker/graph/mwbmatching.cpp
+++ b/Tracker/graph/mwbmatching.cpp
@@ -25,10 +25,13 @@
 #endif
 
 
-mwbmatching::mwbmatching () : algorithm () 
+mwbmatching::mwbmatching ()
+    :
+      algorithm(),
+      mwbm(0),
+      set_vars_executed(false),
+      pq(NULL)
 {
-	set_vars_executed = false;
-	pq = NULL;
 }
 
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Error: V730 Not all members of a class are initialized inside the constructor. Consider inspecting: pos.
