### PR TITLE
Fixed memory allocation error

### DIFF
--- a/Tracker/HungarianAlg/HungarianAlg.cpp
+++ b/Tracker/HungarianAlg/HungarianAlg.cpp
@@ -59,6 +59,12 @@ void AssignmentProblemSolver::assignmentoptimal(assignments_t& assignment, track
 	size_t nOfElements = nOfRows * nOfColumns;
 	// Memory allocation
 	track_t* distMatrix = (track_t *)malloc(nOfElements * sizeof(track_t));
+
+    if (distMatrix == nullptr)
+    {
+        return;
+    }
+
 	// Pointer to last element
 	track_t* distMatrixEnd = distMatrix + nOfElements;
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warning: V769 The 'distMatrix' pointer in the 'distMatrix + nOfElements' expression could be nullptr. In such case, resulting value will be senseless and it should not be used. Check lines: 63, 61.
