### PR TITLE
Fixed type cast from int to float

### DIFF
--- a/Tracker/track.cpp
+++ b/Tracker/track.cpp
@@ -58,8 +58,8 @@ track_t CTrack::CalcDist(const Point_t& pt) const
 track_t CTrack::CalcDist(const cv::Rect& r) const
 {
     std::array<track_t, 4> diff;
-    diff[0] = m_predictionPoint.x - m_lastRegion.m_rect.width / 2 - r.x;
-    diff[1] = m_predictionPoint.y - m_lastRegion.m_rect.height / 2 - r.y;
+    diff[0] = m_predictionPoint.x - m_lastRegion.m_rect.width / 2.f - r.x;
+    diff[1] = m_predictionPoint.y - m_lastRegion.m_rect.height / 2.f - r.y;
     diff[2] = static_cast<track_t>(m_lastRegion.m_rect.width - r.width);
     diff[3] = static_cast<track_t>(m_lastRegion.m_rect.height - r.height);
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warning: V636 The 'm_lastRegion.m_rect.width / 2' expression was implicitly cast from 'int' type to 'float' type. Consider utilizing an explicit type cast to avoid the loss of a fractional part. An example: double A = (double)(X) / Y;.
