### PR TITLE
Option for enabling built-in OpenCL in OpenCV

### DIFF
--- a/Detector/BackgroundSubtract.cpp
+++ b/Detector/BackgroundSubtract.cpp
@@ -88,21 +88,21 @@ BackgroundSubtract::~BackgroundSubtract()
 //----------------------------------------------------------------------
 //
 //----------------------------------------------------------------------
-void BackgroundSubtract::subtract(const cv::Mat& image, cv::Mat& foreground)
+void BackgroundSubtract::subtract(const cv::UMat& image, cv::UMat& foreground)
 {
-	auto GetImg = [&]() -> cv::Mat
+    auto GetImg = [&]() -> cv::UMat
 	{
 		if (image.channels() != m_channels)
 		{
 			if (image.channels() == 1)
 			{
-				cv::Mat newImg;
+                cv::UMat newImg;
 				cv::cvtColor(image, newImg, CV_GRAY2BGR);
 				return newImg;
 			}
 			else if (image.channels() == 3)
 			{
-				cv::Mat newImg;
+                cv::UMat newImg;
 				cv::cvtColor(image, newImg, CV_BGR2GRAY);
 				return newImg;
 			}
@@ -113,8 +113,8 @@ void BackgroundSubtract::subtract(const cv::Mat& image, cv::Mat& foreground)
 	switch (m_algType)
 	{
 	case ALG_VIBE:
-		m_modelVibe->update(GetImg());
-		foreground = m_modelVibe->getMask();
+        m_modelVibe->update(GetImg().getMat(cv::ACCESS_READ));
+        foreground = m_modelVibe->getMask().getUMat(cv::ACCESS_READ);
 		break;
 
 	case ALG_MOG:
@@ -132,7 +132,7 @@ void BackgroundSubtract::subtract(const cv::Mat& image, cv::Mat& foreground)
     case ALG_LOBSTER:
         if (foreground.size() != image.size())
         {
-            m_modelSuBSENSE->initialize(GetImg(), cv::Mat());
+            m_modelSuBSENSE->initialize(GetImg().getMat(cv::ACCESS_READ), cv::Mat());
             foreground.create(image.size(), CV_8UC1);
         }
         else
@@ -146,8 +146,8 @@ void BackgroundSubtract::subtract(const cv::Mat& image, cv::Mat& foreground)
         break;
 
     default:
-        m_modelVibe->update(GetImg());
-        foreground = m_modelVibe->getMask();
+        m_modelVibe->update(GetImg().getMat(cv::ACCESS_READ));
+        foreground = m_modelVibe->getMask().getUMat(cv::ACCESS_READ);
         break;
 	}
 

--- a/Detector/BackgroundSubtract.h
+++ b/Detector/BackgroundSubtract.h
@@ -27,7 +27,7 @@ public:
 	BackgroundSubtract(BGFG_ALGS algType, int channels = 1, int samples = 20, int pixel_neighbor = 1, int distance_threshold = 20, int matching_threshold = 3, int update_factor = 16);
 	~BackgroundSubtract();
 
-	void subtract(const cv::Mat& image, cv::Mat& foreground);
+    void subtract(const cv::UMat& image, cv::UMat& foreground);
 	
 	int m_channels;
 	BGFG_ALGS m_algType;

--- a/Detector/Detector.cpp
+++ b/Detector/Detector.cpp
@@ -6,7 +6,7 @@
 CDetector::CDetector(
 	BackgroundSubtract::BGFG_ALGS algType,
 	bool collectPoints,
-	cv::Mat& gray
+    cv::UMat& gray
 	)
 	: m_collectPoints(collectPoints)
 {
@@ -89,7 +89,7 @@ void CDetector::DetectContour()
 // ---------------------------------------------------------------------------
 //
 // ---------------------------------------------------------------------------
-const std::vector<Point_t>& CDetector::Detect(cv::Mat& gray)
+const std::vector<Point_t>& CDetector::Detect(cv::UMat& gray)
 {
 	m_backgroundSubst->subtract(gray, m_fg);
 

--- a/Detector/Detector.h
+++ b/Detector/Detector.h
@@ -15,7 +15,7 @@ private:
 	std::unique_ptr<BackgroundSubtract> m_backgroundSubst;
     regions_t m_regions;
 	std::vector<Point_t> m_centers;
-	cv::Mat m_fg;
+    cv::UMat m_fg;
 
 	cv::Size m_minObjectSize;
 
@@ -24,8 +24,8 @@ private:
 	cv::Mat m_motionMap;
 
 public:
-	CDetector(BackgroundSubtract::BGFG_ALGS algType, bool collectPoints, cv::Mat& gray);
-	const std::vector<Point_t>& Detect(cv::Mat& gray);
+    CDetector(BackgroundSubtract::BGFG_ALGS algType, bool collectPoints, cv::UMat& gray);
+    const std::vector<Point_t>& Detect(cv::UMat& gray);
 	~CDetector(void);
 
 	void SetMinObjectSize(cv::Size minObjectSize);

--- a/MouseExample.h
+++ b/MouseExample.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include "opencv2/opencv.hpp"
-#include <opencv2/highgui/highgui_c.h>
+//#include <opencv2/highgui/highgui_c.h>
 
 #include "Ctracker.h"
 
@@ -88,7 +87,7 @@ void MouseTracking(cv::CommandLineParser parser)
             cv::circle(frame, pts[i], 3, cv::Scalar(0, 255, 0), 1, CV_AA);
         }
 
-        tracker.Update(pts, regions, cv::Mat());
+        tracker.Update(pts, regions, cv::UMat());
 
         std::cout << tracker.tracks.size() << std::endl;
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Hungarian algorithm + Kalman filter multitarget tracker implementation.
 **Usage:**
 
            Usage:
-             ./MultitargetTracker <path to movie file> [--example]=<number of example 0..3> [--start_frame]=<start a video from this position> [--end_frame]=<play a video to this position> [--end_delay]=<delay in milliseconds after video ending> [--out]=<name of result video file> [--show_logs]=<show logs>
+             ./MultitargetTracker <path to movie file> [--example]=<number of example 0..3> [--start_frame]=<start a video from this position> [--end_frame]=<play a video to this position> [--end_delay]=<delay in milliseconds after video ending> [--out]=<name of result video file> [--show_logs]=<show logs> [--gpu]=<use OpenCL>
              ./MultitargetTracker ../data/atrium.avi -e=1 -o=../data/atrium_motion.avi
            Press:
            * 'm' key for change mode: play|pause. When video is paused you can press any key for get next frame.
@@ -54,6 +54,8 @@ Hungarian algorithm + Kalman filter multitarget tracker implementation.
               -o=out.avi or --out=result.mp4
            7. [Optional] Show Trackers logs in terminal
               -sl=1 or --show_logs=0
+           8. [Optional] Use built-in OpenCL
+              -g=1 or --gpu=0
 
 #### Thirdparty libraries
 * OpenCV (and contrib): https://github.com/opencv/opencv and https://github.com/opencv/opencv_contrib

--- a/Tracker/Ctracker.cpp
+++ b/Tracker/Ctracker.cpp
@@ -51,7 +51,7 @@ CTracker::~CTracker(void)
 void CTracker::Update(
         const std::vector<Point_t>& detections,
         const regions_t& regions,
-        cv::Mat grayFrame
+        cv::UMat grayFrame
         )
 {
     assert(detections.size() == regions.size());

--- a/Tracker/Ctracker.h
+++ b/Tracker/Ctracker.h
@@ -26,7 +26,7 @@ public:
 	~CTracker(void);
 
     tracks_t tracks;
-    void Update(const std::vector<Point_t>& detections, const regions_t& regions, cv::Mat grayFrame);
+    void Update(const std::vector<Point_t>& detections, const regions_t& regions, cv::UMat grayFrame);
 
 private:
     // Use local tracking for regions between two frames
@@ -55,5 +55,5 @@ private:
 
     LocalTracker m_localTracker;
 
-    cv::Mat m_prevFrame;
+    cv::UMat m_prevFrame;
 };

--- a/Tracker/Kalman.cpp
+++ b/Tracker/Kalman.cpp
@@ -1,5 +1,4 @@
 #include "Kalman.h"
-#include "opencv2/opencv.hpp"
 #include <iostream>
 #include <vector>
 

--- a/Tracker/LocalTracker.cpp
+++ b/Tracker/LocalTracker.cpp
@@ -19,8 +19,8 @@ LocalTracker::~LocalTracker(void)
 // ---------------------------------------------------------------------------
 void LocalTracker::Update(
         tracks_t& tracks,
-        cv::Mat prevFrame,
-        cv::Mat currFrame
+        cv::UMat prevFrame,
+        cv::UMat currFrame
         )
 {
     std::vector<cv::Point2f> points[2];

--- a/Tracker/LocalTracker.h
+++ b/Tracker/LocalTracker.h
@@ -11,5 +11,5 @@ public:
     LocalTracker();
     ~LocalTracker(void);
 
-    void Update(tracks_t& tracks, cv::Mat prevFrame, cv::Mat currFrame);
+    void Update(tracks_t& tracks, cv::UMat prevFrame, cv::UMat currFrame);
 };

--- a/Tracker/defines.h
+++ b/Tracker/defines.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <vector>
+#include <string>
 #include <opencv2/opencv.hpp>
+
 
 // ---------------------------------------------------------------------------
 //

--- a/Tracker/track.cpp
+++ b/Tracker/track.cpp
@@ -100,8 +100,8 @@ void CTrack::Update(
         const CRegion& region,
         bool dataCorrect,
         size_t max_trace_length,
-        cv::Mat prevFrame,
-        cv::Mat currFrame
+        cv::UMat prevFrame,
+        cv::UMat currFrame
         )
 {
     if (m_filterObjectSize) // Kalman filter for object coordinates and size
@@ -185,8 +185,8 @@ cv::Rect CTrack::GetLastRect() const
 void CTrack::RectUpdate(
         const CRegion& region,
         bool dataCorrect,
-        cv::Mat prevFrame,
-        cv::Mat currFrame
+        cv::UMat prevFrame,
+        cv::UMat currFrame
         )
 {
     m_kalman->GetRectPrediction();
@@ -237,7 +237,7 @@ void CTrack::RectUpdate(
                         lastRect.y + lastRect.height < roiRect.height &&
                         lastRect.area() > 0)
                 {
-                    m_tracker->init(cv::Mat(prevFrame, roiRect), lastRect);
+                    m_tracker->init(cv::UMat(prevFrame, roiRect), lastRect);
                 }
                 else
                 {
@@ -245,7 +245,7 @@ void CTrack::RectUpdate(
                 }
             }
             cv::Rect2d newRect;
-            if (!m_tracker.empty() && m_tracker->update(cv::Mat(currFrame, roiRect), newRect))
+            if (!m_tracker.empty() && m_tracker->update(cv::UMat(currFrame, roiRect), newRect))
             {
                 cv::Rect prect(cvRound(newRect.x) + roiRect.x, cvRound(newRect.y) + roiRect.y, cvRound(newRect.width), cvRound(newRect.height));
 

--- a/Tracker/track.h
+++ b/Tracker/track.h
@@ -179,7 +179,7 @@ public:
     track_t CalcDist(const cv::Rect& r) const;
     track_t CalcDistJaccard(const cv::Rect& r) const;
 
-    void Update(const Point_t& pt, const CRegion& region, bool dataCorrect, size_t max_trace_length, cv::Mat prevFrame, cv::Mat currFrame);
+    void Update(const Point_t& pt, const CRegion& region, bool dataCorrect, size_t max_trace_length, cv::UMat prevFrame, cv::UMat currFrame);
 
     bool IsRobust(int minTraceSize, float minRawRatio, cv::Size2f sizeRatio) const;
 
@@ -203,7 +203,7 @@ private:
     cv::Ptr<cv::Tracker> m_tracker;
 #endif
 
-    void RectUpdate(const CRegion& region, bool dataCorrect, cv::Mat prevFrame, cv::Mat currFrame);
+    void RectUpdate(const CRegion& region, bool dataCorrect, cv::UMat prevFrame, cv::UMat currFrame);
 
     void CreateExternalTracker();
 

--- a/VideoExample.h
+++ b/VideoExample.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "opencv2/opencv.hpp"
 #include "BackgroundSubtract.h"
 #include "Detector.h"
 
@@ -62,7 +61,7 @@ public:
         }
         cv::namedWindow("Video");
         cv::Mat frame;
-        cv::Mat gray;
+        cv::UMat gray;
 
         capture.set(cv::CAP_PROP_POS_FRAMES, m_startFrame);
 
@@ -136,8 +135,8 @@ public:
     }
 
 protected:
-    virtual bool InitTracker(cv::Mat grayFrame) = 0;
-    virtual void ProcessFrame(cv::Mat grayFrame) = 0;
+    virtual bool InitTracker(cv::UMat grayFrame) = 0;
+    virtual void ProcessFrame(cv::UMat grayFrame) = 0;
     virtual void DrawData(cv::Mat frame, int framesCounter, int currTime) = 0;
 
     bool m_showLogs;
@@ -210,7 +209,7 @@ protected:
     /// \brief InitTracker
     /// \param grayFrame
     ///
-    bool InitTracker(cv::Mat grayFrame)
+    bool InitTracker(cv::UMat grayFrame)
     {
         m_minObjWidth = grayFrame.cols / 50;
 
@@ -237,7 +236,7 @@ protected:
     /// \brief ProcessFrame
     /// \param grayFrame
     ///
-    void ProcessFrame(cv::Mat grayFrame)
+    void ProcessFrame(cv::UMat grayFrame)
     {
         const std::vector<Point_t>& centers = m_detector->Detect(grayFrame);
         const regions_t& regions = m_detector->GetDetects();
@@ -296,7 +295,7 @@ protected:
     /// \brief InitTracker
     /// \param grayFrame
     ///
-    bool InitTracker(cv::Mat /*grayFrame*/)
+    bool InitTracker(cv::UMat /*grayFrame*/)
     {
         std::string fileName = "../data/haarcascade_frontalface_alt2.xml";
         m_cascade.load(fileName);
@@ -326,7 +325,7 @@ protected:
     /// \brief ProcessFrame
     /// \param grayFrame
     ///
-    void ProcessFrame(cv::Mat grayFrame)
+    void ProcessFrame(cv::UMat grayFrame)
     {
         bool findLargestObject = false;
         bool filterRects = true;
@@ -401,7 +400,7 @@ protected:
     /// \brief InitTracker
     /// \param grayFrame
     ///
-    bool InitTracker(cv::Mat /*grayFrame*/)
+    bool InitTracker(cv::UMat /*grayFrame*/)
     {
 #if USE_HOG
         m_hog.setSVMDetector(cv::HOGDescriptor::getDefaultPeopleDetector());
@@ -431,7 +430,7 @@ protected:
     /// \brief ProcessFrame
     /// \param grayFrame
     ///
-    void ProcessFrame(cv::Mat grayFrame)
+    void ProcessFrame(cv::UMat grayFrame)
     {
         std::vector<Point_t> centers;
         regions_t regions;
@@ -523,7 +522,7 @@ protected:
     /// \brief InitTracker
     /// \param grayFrame
     ///
-    bool InitTracker(cv::Mat grayFrame)
+    bool InitTracker(cv::UMat grayFrame)
     {
         std::string fileName = "../data/haarcascade_frontalface_alt2.xml";
         m_cascade.load(fileName);
@@ -556,7 +555,7 @@ protected:
     /// \brief ProcessFrame
     /// \param grayFrame
     ///
-    void ProcessFrame(cv::Mat grayFrame)
+    void ProcessFrame(cv::UMat grayFrame)
     {
         bool findLargestObject = false;
         bool filterRects = true;

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,9 @@
 #include "MouseExample.h"
 #include "VideoExample.h"
 
+#include <opencv2/opencv.hpp>
+#include <opencv2/core/ocl.hpp>
+
 // ----------------------------------------------------------------------
 
 static void Help()
@@ -23,6 +26,7 @@ const char* keys =
     "{ ed end_delay   |0                   | Delay in milliseconds after video ending | }"
     "{ o  out         |                    | Name of result video file | }"
     "{ sl show_logs   |1                   | Show Trackers logs | }"
+    "{ g gpu          |0                   | Use OpenCL acceleration | }"
 };
 
 // ----------------------------------------------------------------------
@@ -33,7 +37,11 @@ int main(int argc, char** argv)
 
     cv::CommandLineParser parser(argc, argv, keys);
 
-    int exampleNum = parser.get<int>("example");;
+    bool useOCL = parser.get<int>("gpu") ? 1 : 0;
+    cv::ocl::setUseOpenCL(useOCL);
+    std::cout << (cv::ocl::useOpenCL() ? "OpenCL is enabled" : "OpenCL not used") << std::endl;
+
+    int exampleNum = parser.get<int>("example");
 
     switch (exampleNum)
     {


### PR DESCRIPTION
You can add --gpu=1 option to the command line for enabling OpenCL processing.
If it was enabled than to the cout will print "OpenCL is enabled" message.
But not all function have OpenCL implementation. Now it is MOG2, KCF, Kalman, SVM etc.
Vibe, SUBSENCE and LOBSTER don't have OpenCL code.

For selection OpenCL device will read: http://answers.opencv.org/question/147932/how-to-change-opencl-device/
