### PR TITLE
Remove detected shadows of BackgroundSubstractionMOG2

### DIFF
--- a/Detector/BackgroundSubtract.cpp
+++ b/Detector/BackgroundSubtract.cpp
@@ -143,6 +143,7 @@ void BackgroundSubtract::subtract(const cv::UMat& image, cv::UMat& foreground)
 
     case ALG_MOG2:
         m_modelOCV->apply(GetImg(), foreground);
+	cv::threshold(foreground, foreground, 200, 255, cv::THRESH_BINARY);
         break;
 
     default:


### PR DESCRIPTION
By using this feature we can detect properly the moving objects and not their shadows. 