### PR TITLE
Added small crops in DNN detector for High resolution videos and small objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,12 @@ set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
              Tracker/track.cpp
              Tracker/HungarianAlg/HungarianAlg.cpp
              Tracker/LocalTracker.cpp
-             Tracker/Kalman.cpp)
+             Tracker/Kalman.cpp
+
+             Tracker/hough3d/hough.cpp
+             Tracker/hough3d/pointcloud.cpp
+             Tracker/hough3d/sphere.cpp
+             Tracker/hough3d/vector3d.cpp)
 
   set(folder_header
              MouseExample.h
@@ -73,7 +78,12 @@ set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
              Tracker/track.h
              Tracker/HungarianAlg/HungarianAlg.h
              Tracker/LocalTracker.h
-             Tracker/Kalman.h)
+             Tracker/Kalman.h
+
+             Tracker/hough3d/hough.h
+             Tracker/hough3d/pointcloud.h
+             Tracker/hough3d/sphere.h
+             Tracker/hough3d/vector3d.h)
 
   set(graph_source
              Tracker/graph/tokenise.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,12 @@ project(MultitargetTracker)
 
 unset(CMAKE_CXX_FLAGS CACHE)
 
+find_package(OpenMP)
+if (OPENMP_FOUND)
+    list(APPEND CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    list(APPEND CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+endif()
+
 if (CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic-errors --std=gnu++14" CACHE STRING COMPILE_FLAGS FORCE)
     set(CMAKE_CXX_FLAGS_RELEASE "-O3 -g -march=native -mtune=native --fast-math -ffast-math -funroll-loops -Wall -DNDEBUG -DBOOST_DISABLE_ASSERTS" CACHE STRING COMPILE_FLAGS FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,7 +231,10 @@ endif(USE_OCV_BGFG)
 
   INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR})
   INCLUDE_DIRECTORIES(${OpenCV_INCLUDE_DIRS})
+
+if (EIGEN3_FOUND)
   INCLUDE_DIRECTORIES("${EIGEN3_INCLUDE_DIR}")
+endif()
 
 # ----------------------------------------------------------------------------
 # и Lib-ы opencv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,11 @@ set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/build)
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 
-find_package(Eigen3)
+option(USE_HOUGH3D "Should use the Hough3D for trajectories matching?" OFF)
+if (USE_HOUGH3D)
+    find_package(Eigen3)
+    add_definitions(-DUSE_HOUGH3D)
+endif()
 
 # ----------------------------------------------------------------------------
 # Предполагаем, что FindOpenCV.cmake расположен по адресу CMAKE_MODULE_PATH.
@@ -55,13 +59,9 @@ find_package(Eigen3)
              Tracker/HungarianAlg/HungarianAlg.cpp
              Tracker/LocalTracker.cpp
              Tracker/Kalman.cpp
+)
 
-             Tracker/hough3d/hough.cpp
-             Tracker/hough3d/pointcloud.cpp
-             Tracker/hough3d/sphere.cpp
-             Tracker/hough3d/vector3d.cpp)
-
-  set(folder_header
+  set(folder_headers
              MouseExample.h
              VideoExample.h
              nms.h
@@ -87,11 +87,22 @@ find_package(Eigen3)
              Tracker/HungarianAlg/HungarianAlg.h
              Tracker/LocalTracker.h
              Tracker/Kalman.h
+)
 
+
+if (USE_HOUGH3D)
+    set(folder_source ${folder_source}
+             Tracker/hough3d/hough.cpp
+             Tracker/hough3d/pointcloud.cpp
+             Tracker/hough3d/sphere.cpp
+             Tracker/hough3d/vector3d.cpp)
+
+    set(folder_headers ${folder_headers}
              Tracker/hough3d/hough.h
              Tracker/hough3d/pointcloud.h
              Tracker/hough3d/sphere.h
              Tracker/hough3d/vector3d.h)
+endif()
 
   set(graph_source
              Tracker/graph/tokenise.cpp
@@ -186,7 +197,7 @@ find_package(Eigen3)
              )
 
   SOURCE_GROUP("Source Files" FILES ${folder_source})
-  SOURCE_GROUP("Header Files" FILES ${folder_header})
+  SOURCE_GROUP("Header Files" FILES ${folder_headers})
 
   SOURCE_GROUP("graph" FILES ${graph_source} ${graph_header})
   SOURCE_GROUP("GTL" FILES ${gtl_source} ${gtl_header})
@@ -222,7 +233,7 @@ endif(USE_OCV_BGFG)
 # ----------------------------------------------------------------------------  
 # создаем проект
 # ----------------------------------------------------------------------------
-  ADD_EXECUTABLE(MultitargetTracker ${folder_source} ${folder_header} ${graph_source} ${graph_header} ${gtl_source} ${gtl_header})
+  ADD_EXECUTABLE(MultitargetTracker ${folder_source} ${folder_headers} ${graph_source} ${graph_header} ${gtl_source} ${gtl_header})
 # ----------------------------------------------------------------------------
 # добавляем include директории
 # ----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/build)
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 
+find_package(Eigen3)
+
 # ----------------------------------------------------------------------------
 # Предполагаем, что FindOpenCV.cmake расположен по адресу CMAKE_MODULE_PATH.
 # ----------------------------------------------------------------------------
@@ -229,6 +231,8 @@ endif(USE_OCV_BGFG)
 
   INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR})
   INCLUDE_DIRECTORIES(${OpenCV_INCLUDE_DIRS})
+  INCLUDE_DIRECTORIES("${EIGEN3_INCLUDE_DIR}")
+
 # ----------------------------------------------------------------------------
 # и Lib-ы opencv
 # ----------------------------------------------------------------------------

--- a/Detector/DNNDetector.h
+++ b/Detector/DNNDetector.h
@@ -29,5 +29,6 @@ private:
     float m_inScaleFactor;
     float m_meanVal;
     float m_confidenceThreshold;
+    float m_maxCropRatio;
     std::vector<std::string> m_classNames;
 };

--- a/MouseExample.h
+++ b/MouseExample.h
@@ -87,7 +87,7 @@ void MouseTracking(cv::CommandLineParser parser)
             cv::circle(frame, pts[i], 3, cv::Scalar(0, 255, 0), 1, CV_AA);
         }
 
-        tracker.Update(regions, cv::UMat());
+        tracker.Update(regions, cv::UMat(), 100);
 
         std::cout << tracker.tracks.size() << std::endl;
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Hungarian algorithm + Kalman filter multitarget tracker implementation.
 
 * MobileNet SSD and tracking for low resolution and low quality videos from car DVR:
 
-[![Tracking:](https://img.youtube.com/vi/gVFXZ3-BNhA/0.jpg)](https://www.youtube.com/watch?v=gVFXZ3-BNhA)
+[![Tracking:](https://img.youtube.com/vi/Qssz6tVGoOc/0.jpg)](https://youtu.be/Qssz6tVGoOc)
 
 * Mouse tracking:
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Hungarian algorithm + Kalman filter multitarget tracker implementation.
 
 #### Demo Videos
 
+* MobileNet SSD and tracking for low resolution and low quality videos from car DVR:
+
+[![Tracking:](https://img.youtube.com/vi/gVFXZ3-BNhA/0.jpg)](https://www.youtube.com/watch?v=gVFXZ3-BNhA)
+
 * Mouse tracking:
 
 [![Tracking:](https://img.youtube.com/vi/2fW5TmAtAXM/0.jpg)](https://www.youtube.com/watch?v=2fW5TmAtAXM)

--- a/Tracker/Ctracker.cpp
+++ b/Tracker/Ctracker.cpp
@@ -6,8 +6,10 @@
 #include "mwbmatching.h"
 #include "tokenise.h"
 
+#ifdef USE_HOUGH3D
 #include "hough3d/hough.h"
 #include <Eigen/Dense>
+#endif
 
 // ---------------------------------------------------------------------------
 // Tracker. Manage tracks. Create, remove, update.
@@ -49,6 +51,7 @@ CTracker::~CTracker(void)
 {
 }
 
+#ifdef USE_HOUGH3D
 //
 // orthogonal least squares fit with libeigen
 // rc = largest eigenvalue
@@ -84,7 +87,7 @@ int orthogonal_LSQ(const PointCloud &pc, Vector3d* a, Vector3d* b)
     int rc = eig.eigenvalues()(2);
     return rc;
 }
-
+#endif
 // ---------------------------------------------------------------------------
 //
 // ---------------------------------------------------------------------------
@@ -102,11 +105,13 @@ void CTracker::Update(
         }
     }
 
+#ifdef USE_HOUGH3D
     if (m_useHough3D)
     {
         UpdateHough3D(regions, grayFrame, fps);
     }
     else
+#endif
     {
         UpdateHungrian(regions, grayFrame, fps);
     }
@@ -318,6 +323,7 @@ void CTracker::UpdateHungrian(
 // ---------------------------------------------------------------------------
 //
 // ---------------------------------------------------------------------------
+#ifdef USE_HOUGH3D
 void CTracker::UpdateHough3D(
         const regions_t& regions,
         cv::UMat grayFrame,
@@ -457,3 +463,4 @@ void CTracker::UpdateHough3D(
         }
     }
 }
+#endif

--- a/Tracker/Ctracker.cpp
+++ b/Tracker/Ctracker.cpp
@@ -90,7 +90,8 @@ int orthogonal_LSQ(const PointCloud &pc, Vector3d* a, Vector3d* b)
 // ---------------------------------------------------------------------------
 void CTracker::Update(
         const regions_t& regions,
-        cv::UMat grayFrame
+        cv::UMat grayFrame,
+        float fps
         )
 {
     if (m_prevFrame.size() == grayFrame.size())
@@ -101,6 +102,27 @@ void CTracker::Update(
         }
     }
 
+    if (m_useHough3D)
+    {
+        UpdateHough3D(regions, grayFrame, fps);
+    }
+    else
+    {
+        UpdateHungrian(regions, grayFrame, fps);
+    }
+
+    grayFrame.copyTo(m_prevFrame);
+}
+
+// ---------------------------------------------------------------------------
+//
+// ---------------------------------------------------------------------------
+void CTracker::UpdateHungrian(
+        const regions_t& regions,
+        cv::UMat grayFrame,
+        float fps
+        )
+{
     // -----------------------------------
     // If there is no tracks yet, then every cv::Point begins its own track.
     // -----------------------------------
@@ -119,8 +141,204 @@ void CTracker::Update(
         }
     }
 
-    if (m_useHough3D)
+    size_t N = tracks.size();		// треки
+    size_t M = regions.size();	// детекты
+
+    assignments_t assignment(N, -1); // назначения
+
+    if (!tracks.empty())
     {
+        // Матрица расстояний от N-ного трека до M-ного детекта.
+        distMatrix_t Cost(N * M);
+
+        // -----------------------------------
+        // Треки уже есть, составим матрицу расстояний
+        // -----------------------------------
+        const track_t maxPossibleCost = grayFrame.cols * grayFrame.rows;
+        track_t maxCost = 0;
+        switch (m_distType)
+        {
+        case tracking::DistCenters:
+            for (size_t i = 0; i < tracks.size(); i++)
+            {
+                for (size_t j = 0; j < regions.size(); j++)
+                {
+                    auto dist = tracks[i]->CheckType(regions[j].m_type) ? tracks[i]->CalcDist((regions[j].m_rect.tl() + regions[j].m_rect.br()) / 2) : maxPossibleCost;
+                    Cost[i + j * N] = dist;
+                    if (dist > maxCost)
+                    {
+                        maxCost = dist;
+                    }
+                }
+            }
+            break;
+
+        case tracking::DistRects:
+            for (size_t i = 0; i < tracks.size(); i++)
+            {
+                for (size_t j = 0; j < regions.size(); j++)
+                {
+                    auto dist = tracks[i]->CheckType(regions[j].m_type) ? tracks[i]->CalcDist(regions[j].m_rect) : maxPossibleCost;
+                    Cost[i + j * N] = dist;
+                    if (dist > maxCost)
+                    {
+                        maxCost = dist;
+                    }
+                }
+            }
+            break;
+
+        case tracking::DistJaccard:
+            for (size_t i = 0; i < tracks.size(); i++)
+            {
+                for (size_t j = 0; j < regions.size(); j++)
+                {
+                    auto dist = tracks[i]->CheckType(regions[j].m_type) ? tracks[i]->CalcDistJaccard(regions[j].m_rect) : 1;
+                    Cost[i + j * N] = dist;
+                    if (dist > maxCost)
+                    {
+                        maxCost = dist;
+                    }
+                }
+            }
+            break;
+        }
+        // -----------------------------------
+        // Solving assignment problem (tracks and predictions of Kalman filter)
+        // -----------------------------------
+        if (m_matchType == tracking::MatchHungrian)
+        {
+            AssignmentProblemSolver APS;
+            APS.Solve(Cost, N, M, assignment, AssignmentProblemSolver::optimal);
+        }
+        else
+        {
+            MyGraph G;
+            G.make_directed();
+
+            std::vector<node> nodes(N + M);
+
+            for (size_t i = 0; i < nodes.size(); ++i)
+            {
+                nodes[i] = G.new_node();
+            }
+
+            edge_map<int> weights(G, 100);
+            for (size_t i = 0; i < tracks.size(); i++)
+            {
+                bool hasZeroEdge = false;
+
+                for (size_t j = 0; j < regions.size(); j++)
+                {
+                    track_t currCost = Cost[i + j * N];
+
+                    edge e = G.new_edge(nodes[i], nodes[N + j]);
+
+                    if (currCost < dist_thres)
+                    {
+                        int weight = maxCost - currCost + 1;
+                        G.set_edge_weight(e, weight);
+                        weights[e] = weight;
+                    }
+                    else
+                    {
+                        if (!hasZeroEdge)
+                        {
+                            G.set_edge_weight(e, 0);
+                            weights[e] = 0;
+                        }
+                        hasZeroEdge = true;
+                    }
+                }
+            }
+
+            edges_t L = MAX_WEIGHT_BIPARTITE_MATCHING(G, weights);
+            for (edges_t::iterator it = L.begin(); it != L.end(); ++it)
+            {
+                node a = it->source();
+                node b = it->target();
+                assignment[b.id()] = a.id() - N;
+            }
+        }
+
+        // -----------------------------------
+        // clean assignment from pairs with large distance
+        // -----------------------------------
+        for (size_t i = 0; i < assignment.size(); i++)
+        {
+            if (assignment[i] != -1)
+            {
+                if (Cost[i + assignment[i] * N] > dist_thres)
+                {
+                    assignment[i] = -1;
+                    tracks[i]->m_skippedFrames++;
+                }
+            }
+            else
+            {
+                // If track have no assigned detect, then increment skipped frames counter.
+                tracks[i]->m_skippedFrames++;
+            }
+        }
+
+        // -----------------------------------
+        // If track didn't get detects long time, remove it.
+        // -----------------------------------
+        for (int i = 0; i < static_cast<int>(tracks.size()); i++)
+        {
+            if (tracks[i]->m_skippedFrames > maximum_allowed_skipped_frames)
+            {
+                tracks.erase(tracks.begin() + i);
+                assignment.erase(assignment.begin() + i);
+                i--;
+            }
+        }
+    }
+
+    // -----------------------------------
+    // Search for unassigned detects and start new tracks for them.
+    // -----------------------------------
+    for (size_t i = 0; i < regions.size(); ++i)
+    {
+        if (find(assignment.begin(), assignment.end(), i) == assignment.end())
+        {
+            tracks.push_back(std::make_unique<CTrack>(regions[i],
+                                                      m_kalmanType,
+                                                      dt,
+                                                      accelNoiseMag,
+                                                      NextTrackID++,
+                                                      m_filterGoal == tracking::FilterRect,
+                                                      m_lostTrackType));
+        }
+    }
+
+    // Update Kalman Filters state
+
+    for (size_t i = 0; i < assignment.size(); i++)
+    {
+        // If track updated less than one time, than filter state is not correct.
+
+        if (assignment[i] != -1) // If we have assigned detect, then update using its coordinates,
+        {
+            tracks[i]->m_skippedFrames = 0;
+            tracks[i]->Update(regions[assignment[i]], true, max_trace_length, m_prevFrame, grayFrame);
+        }
+        else				     // if not continue using predictions
+        {
+            tracks[i]->Update(CRegion(), false, max_trace_length, m_prevFrame, grayFrame);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+//
+// ---------------------------------------------------------------------------
+void CTracker::UpdateHough3D(
+        const regions_t& regions,
+        cv::UMat grayFrame,
+        float fps
+        )
+{
         std::vector<Point_t> points3d;
 
         for (const auto& region : regions)
@@ -136,7 +354,7 @@ void CTracker::Update(
 
         if (m_points3D.size() == Hough3DTimeline)
         {
-            track_t dTime = 33; // It's for 30 fps videos: 1000 ms / 30 fps ~= 33
+            track_t dTime = std::max(1.f, 1000.f / fps);
 
             size_t allPoints = 0;
             for (const auto& points : m_points3D)
@@ -251,195 +469,4 @@ void CTracker::Update(
                 }
             }
         }
-    }
-
-    size_t N = tracks.size();		// треки
-    size_t M = regions.size();	// детекты
-
-    assignments_t assignment(N, -1); // назначения
-
-    if (!tracks.empty())
-    {
-        // Матрица расстояний от N-ного трека до M-ного детекта.
-        distMatrix_t Cost(N * M);
-
-        // -----------------------------------
-        // Треки уже есть, составим матрицу расстояний
-        // -----------------------------------
-        const track_t maxPossibleCost = grayFrame.cols * grayFrame.rows;
-        track_t maxCost = 0;
-		switch (m_distType)
-        {
-        case tracking::DistCenters:
-            for (size_t i = 0; i < tracks.size(); i++)
-            {
-                for (size_t j = 0; j < regions.size(); j++)
-                {
-                    auto dist = tracks[i]->CheckType(regions[j].m_type) ? tracks[i]->CalcDist((regions[j].m_rect.tl() + regions[j].m_rect.br()) / 2) : maxPossibleCost;
-					Cost[i + j * N] = dist;
-					if (dist > maxCost)
-					{
-						maxCost = dist;
-					}
-                }
-            }
-            break;
-
-        case tracking::DistRects:
-            for (size_t i = 0; i < tracks.size(); i++)
-            {
-                for (size_t j = 0; j < regions.size(); j++)
-                {
-                    auto dist = tracks[i]->CheckType(regions[j].m_type) ? tracks[i]->CalcDist(regions[j].m_rect) : maxPossibleCost;
-					Cost[i + j * N] = dist;
-					if (dist > maxCost)
-					{
-						maxCost = dist;
-					}
-                }
-            }
-            break;
-
-        case tracking::DistJaccard:
-            for (size_t i = 0; i < tracks.size(); i++)
-            {
-                for (size_t j = 0; j < regions.size(); j++)
-                {
-                    auto dist = tracks[i]->CheckType(regions[j].m_type) ? tracks[i]->CalcDistJaccard(regions[j].m_rect) : 1;
-                    Cost[i + j * N] = dist;
-                    if (dist > maxCost)
-                    {
-                        maxCost = dist;
-                    }
-                }
-            }
-            break;
-        }
-        // -----------------------------------
-        // Solving assignment problem (tracks and predictions of Kalman filter)
-        // -----------------------------------
-        if (m_matchType == tracking::MatchHungrian)
-		{
-			AssignmentProblemSolver APS;
-			APS.Solve(Cost, N, M, assignment, AssignmentProblemSolver::optimal);
-		}
-		else
-		{
-			MyGraph G;
-			G.make_directed();
-
-			std::vector<node> nodes(N + M);
-
-			for (size_t i = 0; i < nodes.size(); ++i)
-			{
-				nodes[i] = G.new_node();
-			}
-
-			edge_map<int> weights(G, 100);
-			for (size_t i = 0; i < tracks.size(); i++)
-			{
-				bool hasZeroEdge = false;
-
-                for (size_t j = 0; j < regions.size(); j++)
-				{
-					track_t currCost = Cost[i + j * N];
-
-					edge e = G.new_edge(nodes[i], nodes[N + j]);
-
-					if (currCost < dist_thres)
-					{
-						int weight = maxCost - currCost + 1;
-						G.set_edge_weight(e, weight);
-						weights[e] = weight;
-					}
-					else
-					{
-						if (!hasZeroEdge)
-						{
-							G.set_edge_weight(e, 0);
-							weights[e] = 0;
-						}
-						hasZeroEdge = true;
-					}
-				}
-			}
-
-			edges_t L = MAX_WEIGHT_BIPARTITE_MATCHING(G, weights);
-			for (edges_t::iterator it = L.begin(); it != L.end(); ++it)
-			{
-				node a = it->source();
-				node b = it->target();
-				assignment[b.id()] = a.id() - N;
-			}
-		}
-
-		// -----------------------------------
-		// clean assignment from pairs with large distance
-		// -----------------------------------
-		for (size_t i = 0; i < assignment.size(); i++)
-		{
-			if (assignment[i] != -1)
-			{
-				if (Cost[i + assignment[i] * N] > dist_thres)
-				{
-					assignment[i] = -1;
-                    tracks[i]->m_skippedFrames++;
-				}
-			}
-			else
-			{
-				// If track have no assigned detect, then increment skipped frames counter.
-                tracks[i]->m_skippedFrames++;
-			}
-		}
-
-		// -----------------------------------
-        // If track didn't get detects long time, remove it.
-        // -----------------------------------
-        for (int i = 0; i < static_cast<int>(tracks.size()); i++)
-        {
-            if (tracks[i]->m_skippedFrames > maximum_allowed_skipped_frames)
-            {
-                tracks.erase(tracks.begin() + i);
-                assignment.erase(assignment.begin() + i);
-                i--;
-            }
-        }
-    }
-
-    // -----------------------------------
-    // Search for unassigned detects and start new tracks for them.
-    // -----------------------------------
-    for (size_t i = 0; i < regions.size(); ++i)
-    {
-        if (find(assignment.begin(), assignment.end(), i) == assignment.end())
-        {
-            tracks.push_back(std::make_unique<CTrack>(regions[i],
-                                                      m_kalmanType,
-                                                      dt,
-                                                      accelNoiseMag,
-                                                      NextTrackID++,
-                                                      m_filterGoal == tracking::FilterRect,
-                                                      m_lostTrackType));
-        }
-    }
-
-    // Update Kalman Filters state
-
-    for (size_t i = 0; i < assignment.size(); i++)
-    {
-        // If track updated less than one time, than filter state is not correct.
-
-        if (assignment[i] != -1) // If we have assigned detect, then update using its coordinates,
-        {
-            tracks[i]->m_skippedFrames = 0;
-            tracks[i]->Update(regions[assignment[i]], true, max_trace_length, m_prevFrame, grayFrame);
-        }
-        else				     // if not continue using predictions
-        {
-            tracks[i]->Update(CRegion(), false, max_trace_length, m_prevFrame, grayFrame);
-        }
-    }
-
-    grayFrame.copyTo(m_prevFrame);
 }

--- a/Tracker/Ctracker.cpp
+++ b/Tracker/Ctracker.cpp
@@ -34,7 +34,8 @@ CTracker::CTracker(
       dist_thres(dist_thres_),
       maximum_allowed_skipped_frames(maximum_allowed_skipped_frames_),
       max_trace_length(max_trace_length_),
-      NextTrackID(0)
+      NextTrackID(0),
+      m_useHough3D(true)
 {
 }
 

--- a/Tracker/Ctracker.cpp
+++ b/Tracker/Ctracker.cpp
@@ -6,6 +6,9 @@
 #include "mwbmatching.h"
 #include "tokenise.h"
 
+#include "hough3d/hough.h"
+#include <Eigen/Dense>
+
 // ---------------------------------------------------------------------------
 // Tracker. Manage tracks. Create, remove, update.
 // ---------------------------------------------------------------------------
@@ -46,6 +49,42 @@ CTracker::~CTracker(void)
 {
 }
 
+//
+// orthogonal least squares fit with libeigen
+// rc = largest eigenvalue
+//
+int orthogonal_LSQ(const PointCloud &pc, Vector3d* a, Vector3d* b)
+{
+    // anchor point is mean value
+    *a = pc.meanValue();
+
+    // copy points to libeigen matrix
+    Eigen::MatrixXf points = Eigen::MatrixXf::Constant(pc.points.size(), 3, 0);
+    for (int i = 0; i < points.rows(); i++)
+    {
+        points(i, 0) = pc.points.at(i).x;
+        points(i, 1) = pc.points.at(i).y;
+        points(i, 2) = pc.points.at(i).z;
+    }
+
+    // compute scatter matrix ...
+    Eigen::MatrixXf centered = points.rowwise() - points.colwise().mean();
+    Eigen::MatrixXf scatter = (centered.adjoint() * centered);
+
+    // ... and its eigenvalues and eigenvectors
+    Eigen::SelfAdjointEigenSolver<Eigen::MatrixXf> eig(scatter);
+    Eigen::MatrixXf eigvecs = eig.eigenvectors();
+
+    // we need eigenvector to largest eigenvalue
+    // libeigen yields it as LAST column
+    b->x = eigvecs(0, 2);
+    b->y = eigvecs(1, 2);
+    b->z = eigvecs(2, 2);
+
+    int rc = eig.eigenvalues()(2);
+    return rc;
+}
+
 // ---------------------------------------------------------------------------
 //
 // ---------------------------------------------------------------------------
@@ -77,6 +116,140 @@ void CTracker::Update(
                                                       NextTrackID++,
                                                       m_filterGoal == tracking::FilterRect,
                                                       m_lostTrackType));
+        }
+    }
+
+    if (m_useHough3D)
+    {
+        std::vector<Point_t> points3d;
+
+        for (const auto& region : regions)
+        {
+            points3d.push_back(Point_t((region.m_rect.tl() + region.m_rect.br()) / 2));
+        }
+
+        m_points3D.push_back(points3d);
+        if (m_points3D.size() > Hough3DTimeline)
+        {
+            m_points3D.pop_front();
+        }
+
+        if (m_points3D.size() == Hough3DTimeline)
+        {
+            track_t dTime = 33; // It's for 30 fps videos: 1000 ms / 30 fps ~= 33
+
+            size_t allPoints = 0;
+            for (const auto& points : m_points3D)
+            {
+                allPoints += points.size();
+            }
+
+            if (allPoints > 2)
+            {
+                PointCloud X;
+                X.points.reserve(allPoints);
+
+                track_t ptTime = 0;
+                for (const auto& points : m_points3D)
+                {
+                    for (const auto& pt : points)
+                    {
+                        X.points.push_back(Vector3d(ptTime, pt.x, pt.y));
+                    }
+
+                    ptTime += dTime;
+                }
+
+                // center cloud and compute new bounding box
+                Vector3d minP;
+                Vector3d maxP;
+                X.getMinMax3D(&minP, &maxP);
+                track_t d = (maxP - minP).norm();
+                X.shiftToOrigin();
+                Vector3d minPshifted;
+                Vector3d maxPshifted;
+                X.getMinMax3D(&minPshifted, &maxPshifted);
+
+                // estimate size of Hough space
+                // number of icosahedron subdivisions for direction discretization
+                int granularity = 4;
+                int num_directions[7] = {12, 21, 81, 321, 1281, 5121, 20481};
+
+                track_t opt_dx = d / 64.0;
+
+                track_t num_x = floor(d / opt_dx + 0.5f);
+                track_t num_cells = num_x * num_x * num_directions[granularity];
+
+                std::unique_ptr<Hough> hough = std::make_unique<Hough>(minPshifted, maxPshifted, opt_dx, granularity);
+                hough->add(X);
+
+                // iterative Hough transform (Algorithm 1 in IPOL paper)
+                PointCloud Y;	// points close to line
+                size_t opt_minvotes = Hough3DTimeline / 2;
+                std::deque<std::pair<Vector3d, Vector3d>> lines;
+                do
+                {
+                    Vector3d a; // anchor point of line
+                    Vector3d b; // direction of line
+
+                    hough->subtract(Y); // do it here to save one call
+
+                    hough->getLine(&a, &b);
+
+                    X.pointsCloseToLine(a, b, opt_dx, &Y);
+
+                    if (!orthogonal_LSQ(Y, &a, &b))
+                        break;
+
+                    X.pointsCloseToLine(a, b, opt_dx, &Y);
+
+                    if (Y.points.size() < opt_minvotes)
+                        break;
+
+                    if (!orthogonal_LSQ(Y, &a, &b))
+                        break;
+
+                    a = a + X.shift;
+
+                    lines.push_back(std::make_pair(a, b));
+
+                    X.removePoints(Y);
+
+                } while (X.points.size() > 1);
+
+                if (1)
+                {
+                    std::cout << "Hough3D: points = " << allPoints << ", lines = " << lines.size() << std::endl;
+
+                    cv::Mat dbgLines;
+                    cv::cvtColor(grayFrame.getMat(cv::ACCESS_READ), dbgLines, CV_GRAY2BGR);
+
+                    for (const auto& points : m_points3D)
+                    {
+                        for (const auto& pt : points)
+                        {
+                            cv::circle(dbgLines, cv::Point(pt.x, pt.y), 4, cv::Scalar(0, 0, 255));
+
+                        }
+                    }
+
+                    for (auto line : lines)
+                    {
+                        track_t minT = line.first.x;
+                        track_t maxT = line.first.x + dTime * (Hough3DTimeline - 1) * line.second.x;
+                        track_t dt = fabs(maxT - minT);
+
+                        //std::cout << "a = " << line.first << ", b = " << line.second << ", dt = " << dt << std::endl;
+
+                        cv::line(dbgLines,
+                                 cv::Point(line.first.y, line.first.z),
+                                 cv::Point(line.first.y + dt * line.second.y, line.first.z + dt * line.second.z),
+                                 cv::Scalar(255, 0, 0),
+                                 2);
+                    }
+                    cv::imshow("hough3d", dbgLines);
+                }
+            }
         }
     }
 

--- a/Tracker/Ctracker.h
+++ b/Tracker/Ctracker.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include <memory>
 #include <array>
+#include <deque>
 
 #include "defines.h"
 #include "track.h"
@@ -62,6 +63,7 @@ private:
 
     cv::UMat m_prevFrame;
 
+    static const int Hough3DTimeline = 12;
     bool m_useHough3D;
-
+    std::deque<std::vector<Point_t>> m_points3D;
 };

--- a/Tracker/Ctracker.h
+++ b/Tracker/Ctracker.h
@@ -27,7 +27,7 @@ public:
 	~CTracker(void);
 
     tracks_t tracks;
-    void Update(const regions_t& regions, cv::UMat grayFrame);
+    void Update(const regions_t& regions, cv::UMat grayFrame, float fps);
 
     bool GrayFrameToTrack() const
     {
@@ -66,4 +66,7 @@ private:
     static const int Hough3DTimeline = 12;
     bool m_useHough3D;
     std::deque<std::vector<Point_t>> m_points3D;
+
+    void UpdateHungrian(const regions_t& regions, cv::UMat grayFrame, float fps);
+    void UpdateHough3D(const regions_t& regions, cv::UMat grayFrame, float fps);
 };

--- a/Tracker/Ctracker.h
+++ b/Tracker/Ctracker.h
@@ -68,5 +68,7 @@ private:
     std::deque<std::vector<Point_t>> m_points3D;
 
     void UpdateHungrian(const regions_t& regions, cv::UMat grayFrame, float fps);
+#ifdef USE_HOUGH3D
     void UpdateHough3D(const regions_t& regions, cv::UMat grayFrame, float fps);
+#endif
 };

--- a/Tracker/Ctracker.h
+++ b/Tracker/Ctracker.h
@@ -45,19 +45,19 @@ private:
     tracking::MatchType m_matchType;
 
 	// Шаг времени опроса фильтра
-	track_t dt;
+    track_t m_dt;
 
-	track_t accelNoiseMag;
+    track_t m_accelNoiseMag;
 
 	// Порог расстояния. Если точки находятся дуг от друга на расстоянии,
 	// превышающем этот порог, то эта пара не рассматривается в задаче о назначениях.
-	track_t dist_thres;
+    track_t m_distThres;
 	// Максимальное количество кадров которое трек сохраняется не получая данных о измерений.
-    size_t maximum_allowed_skipped_frames;
+    size_t m_maximumAllowedSkippedFrames;
 	// Максимальная длина следа
-    size_t max_trace_length;
+    size_t m_maxTraceLength;
 
-	size_t NextTrackID;
+    size_t m_nextTrackID;
 
     LocalTracker m_localTracker;
 

--- a/Tracker/Ctracker.h
+++ b/Tracker/Ctracker.h
@@ -61,4 +61,7 @@ private:
     LocalTracker m_localTracker;
 
     cv::UMat m_prevFrame;
+
+    bool m_useHough3D;
+
 };

--- a/Tracker/graph/GTL/src/pq_tree.cpp
+++ b/Tracker/graph/GTL/src/pq_tree.cpp
@@ -72,7 +72,7 @@ bool pq_tree::bubble_up (std::list<pq_leaf*>& leaves)
     }
     
     sons_iterator next, prev, end;
-    pq_node* father;
+    pq_node* father = nullptr;
     int size = pert_leaves_count;
     
     while (size + block_count + off_the_top > 1) {

--- a/Tracker/hough3d/hough.cpp
+++ b/Tracker/hough3d/hough.cpp
@@ -1,0 +1,131 @@
+//
+// hough.h
+//     Implementation of Algorithm 2 (Hough transform) from IPOL paper
+//
+// Author:  Tilman Schramke, Manuel Jeltsch, Christoph Dalitz
+// Date:    2017-03-16
+// License: see LICENSE-BSD2
+//
+
+#include "hough.h"
+#include <math.h>
+
+#include <cstdlib>
+
+
+static double roundToNearest(double num) {
+  return (num > 0.0) ? floor(num + 0.5) : ceil(num - 0.5);
+}
+
+Hough::Hough(const Vector3d& minP, const Vector3d& maxP, double var_dx,
+             unsigned int sphereGranularity) {
+
+  // compute directional vectors
+  sphere = new Sphere();
+  sphere->fromIcosahedron(sphereGranularity);
+  num_b = sphere->vertices.size();
+
+  // compute x'y' discretization
+  max_x = std::max(maxP.norm(), minP.norm());
+  double range_x = 2 * max_x;
+  dx = var_dx;
+  if (dx == 0.0) {
+    dx = range_x / 64.0;
+  }
+  num_x = roundToNearest(range_x / dx);
+
+  // allocate voting space
+  VotingSpace.resize(num_x * num_x * num_b);
+}
+
+Hough::~Hough() {
+  delete sphere;
+}
+
+// add all points from point cloud to voting space
+void Hough::add(const PointCloud &pc) {
+  for (std::vector<Vector3d>::const_iterator it = pc.points.begin();
+       it != pc.points.end(); it++) {
+    pointVote((*it), true);
+  }
+}
+
+// subtract all points from point cloud to voting space
+void Hough::subtract(const PointCloud &pc) {
+  for (std::vector<Vector3d>::const_iterator it = pc.points.begin();
+       it != pc.points.end(); it++) {
+    pointVote((*it), false);
+  }
+}
+
+// add or subtract (add==false) one point from voting space
+// (corresponds to inner loop of Algorithm 2 in IPOL paper)
+void Hough::pointVote(const Vector3d& point, bool add){
+
+  // loop over directions B
+  for(size_t j = 0; j < sphere->vertices.size(); j++) {
+
+    Vector3d b = sphere->vertices[j];
+    double beta = 1 / (1 + b.z);	// denominator in Eq. (2)
+
+    // compute x' according to left hand side of Eq. (2)
+    double x_new = ((1 - (beta * (b.x * b.x))) * point.x)
+      - ((beta * (b.x * b.y)) * point.y)
+      - (b.x * point.z);
+
+    // compute y' according to right hand side Eq. (2)
+    double y_new = ((-beta * (b.x * b.y)) * point.x)
+      + ((1 - (beta * (b.y * b.y))) * point.y)
+      - (b.y * point.z);
+
+    size_t x_i = roundToNearest((x_new + max_x) / dx);
+    size_t y_i = roundToNearest((y_new + max_x) / dx);
+
+    // compute one-dimensional index from three indices
+	// x_i * #planes * #direction_Vec + y_i * #direction_Vec + #loop
+    size_t index = (x_i * num_x * num_b) + (y_i * num_b) + j;
+
+    if (index < VotingSpace.size()) {
+      if(add){
+        VotingSpace[index]++;
+      } else {
+        VotingSpace[index]--;
+      }
+    }
+  }
+}
+
+// returns the line with most votes (rc = number of votes)
+unsigned int Hough::getLine(Vector3d* a, Vector3d* b){
+  unsigned int votes = 0;
+  unsigned int index = 0;
+
+  for(unsigned int i = 0; i < VotingSpace.size(); i++){
+    if (VotingSpace[i] > votes) {
+      votes = VotingSpace[i];
+      index = i;
+    }
+  }
+
+  // retrieve x' coordinate from VotingSpace[num_x * num_x * num_b]
+  double x = (int) (index / (num_x * num_b));
+  index -= (int) x * num_x * num_b;
+  x = x * dx - max_x;
+
+  // retrieve y' coordinate from VotingSpace[num_x * num_x * num_b]
+  double y = (int) index / num_b;
+  index -= (int) y * num_b;
+  y = y * dx - max_x;
+
+  // retrieve directional vector
+  *b = sphere->vertices[index];
+
+  // compute anchor point according to Eq. (3)
+  a->x = x * (1 - ((b->x * b->x) / (1 + b->z)))
+    - y * ((b->x * b->y) / (1 + b->z));
+  a->y = x * (-((b->x * b->y) / (1 + b->z)))
+     + y * (1 - ((b->y * b->y) / (1 + b->z)));
+  a->z = - x * b->x - y * b->y;
+
+  return votes;
+}

--- a/Tracker/hough3d/hough.cpp
+++ b/Tracker/hough3d/hough.cpp
@@ -13,11 +13,11 @@
 #include <cstdlib>
 
 
-static double roundToNearest(double num) {
+static track_t roundToNearest(track_t num) {
   return (num > 0.0) ? floor(num + 0.5) : ceil(num - 0.5);
 }
 
-Hough::Hough(const Vector3d& minP, const Vector3d& maxP, double var_dx,
+Hough::Hough(const Vector3d& minP, const Vector3d& maxP, track_t var_dx,
              unsigned int sphereGranularity) {
 
   // compute directional vectors
@@ -27,7 +27,7 @@ Hough::Hough(const Vector3d& minP, const Vector3d& maxP, double var_dx,
 
   // compute x'y' discretization
   max_x = std::max(maxP.norm(), minP.norm());
-  double range_x = 2 * max_x;
+  track_t range_x = 2 * max_x;
   dx = var_dx;
   if (dx == 0.0) {
     dx = range_x / 64.0;
@@ -66,15 +66,15 @@ void Hough::pointVote(const Vector3d& point, bool add){
   for(size_t j = 0; j < sphere->vertices.size(); j++) {
 
     Vector3d b = sphere->vertices[j];
-    double beta = 1 / (1 + b.z);	// denominator in Eq. (2)
+    track_t beta = 1 / (1 + b.z);	// denominator in Eq. (2)
 
     // compute x' according to left hand side of Eq. (2)
-    double x_new = ((1 - (beta * (b.x * b.x))) * point.x)
+    track_t x_new = ((1 - (beta * (b.x * b.x))) * point.x)
       - ((beta * (b.x * b.y)) * point.y)
       - (b.x * point.z);
 
     // compute y' according to right hand side Eq. (2)
-    double y_new = ((-beta * (b.x * b.y)) * point.x)
+    track_t y_new = ((-beta * (b.x * b.y)) * point.x)
       + ((1 - (beta * (b.y * b.y))) * point.y)
       - (b.y * point.z);
 
@@ -108,12 +108,12 @@ unsigned int Hough::getLine(Vector3d* a, Vector3d* b){
   }
 
   // retrieve x' coordinate from VotingSpace[num_x * num_x * num_b]
-  double x = (int) (index / (num_x * num_b));
+  track_t x = (int) (index / (num_x * num_b));
   index -= (int) x * num_x * num_b;
   x = x * dx - max_x;
 
   // retrieve y' coordinate from VotingSpace[num_x * num_x * num_b]
-  double y = (int) index / num_b;
+  track_t y = (int) index / num_b;
   index -= (int) y * num_b;
   y = y * dx - max_x;
 

--- a/Tracker/hough3d/hough.cpp
+++ b/Tracker/hough3d/hough.cpp
@@ -12,11 +12,6 @@
 
 #include <cstdlib>
 
-
-static track_t roundToNearest(track_t num) {
-  return (num > 0.0) ? floor(num + 0.5) : ceil(num - 0.5);
-}
-
 Hough::Hough(const Vector3d& minP, const Vector3d& maxP, track_t var_dx,
              unsigned int sphereGranularity) {
 
@@ -30,9 +25,9 @@ Hough::Hough(const Vector3d& minP, const Vector3d& maxP, track_t var_dx,
   track_t range_x = 2 * max_x;
   dx = var_dx;
   if (dx == 0.0) {
-    dx = range_x / 64.0;
+    dx = range_x / 64.0f;
   }
-  num_x = roundToNearest(range_x / dx);
+  num_x = cvRound(range_x / dx);
 
   // allocate voting space
   VotingSpace.resize(num_x * num_x * num_b);
@@ -78,8 +73,8 @@ void Hough::pointVote(const Vector3d& point, bool add){
       + ((1 - (beta * (b.y * b.y))) * point.y)
       - (b.y * point.z);
 
-    size_t x_i = roundToNearest((x_new + max_x) / dx);
-    size_t y_i = roundToNearest((y_new + max_x) / dx);
+	size_t x_i = cvRound((x_new + max_x) / dx);
+	size_t y_i = cvRound((y_new + max_x) / dx);
 
     // compute one-dimensional index from three indices
 	// x_i * #planes * #direction_Vec + y_i * #direction_Vec + #loop

--- a/Tracker/hough3d/hough.h
+++ b/Tracker/hough3d/hough.h
@@ -1,0 +1,48 @@
+//
+// hough.h
+//     Implementation of Algorithm 2 (Hough transform) from IPOL paper
+//
+// Author:  Tilman Schramke, Manuel Jeltsch, Christoph Dalitz
+// Date:    2017-03-16
+// License: see LICENSE-BSD2
+//
+
+#ifndef HOUGH_H_
+#define HOUGH_H_
+
+
+#include "vector3d.h"
+#include "sphere.h"
+#include "pointcloud.h"
+#include <vector>
+#include <deque>
+
+class Hough {
+public:
+  // accumulator array A
+  std::vector<unsigned int> VotingSpace;
+  // Directions B
+  Sphere *sphere;
+  size_t num_b;
+  // x' and y'
+  double dx, max_x;
+  size_t num_x;
+
+  // parameter space discretization and allocation of voting space
+  Hough(const Vector3d& minP, const Vector3d& maxP, double dx,
+        unsigned int sphereGranularity);
+  ~Hough();
+  // returns the line with most votes (rc = number of votes)
+  unsigned int getLine(Vector3d* point, Vector3d* direction);
+  // add all points from point cloud to voting space
+  void add(const PointCloud &pc);
+  // subtract all points from point cloud to voting space
+  void subtract(const PointCloud &pc);
+
+private:
+  // add or subtract (add==false) one point from voting space
+  void pointVote(const Vector3d& point, bool add);
+
+};
+
+#endif /* HOUGH_H_ */

--- a/Tracker/hough3d/hough.h
+++ b/Tracker/hough3d/hough.h
@@ -25,11 +25,11 @@ public:
   Sphere *sphere;
   size_t num_b;
   // x' and y'
-  double dx, max_x;
+  track_t dx, max_x;
   size_t num_x;
 
   // parameter space discretization and allocation of voting space
-  Hough(const Vector3d& minP, const Vector3d& maxP, double dx,
+  Hough(const Vector3d& minP, const Vector3d& maxP, track_t dx,
         unsigned int sphereGranularity);
   ~Hough();
   // returns the line with most votes (rc = number of votes)

--- a/Tracker/hough3d/pointcloud.cpp
+++ b/Tracker/hough3d/pointcloud.cpp
@@ -1,0 +1,126 @@
+//
+// pointcloud.cpp
+//     Class for holding a set of 3D points
+//
+// Author:  Tilman Schramke, Christoph Dalitz
+// Date:    2017-03-16
+// License: see LICENSE-BSD2
+//
+
+#include "pointcloud.h"
+#include <stdio.h>
+#include <math.h>
+#include <string>
+
+
+// translate point cloud so that center = origin
+// total shift applied to this point cloud is stored in this->shift
+void PointCloud::shiftToOrigin(){
+  Vector3d p1, p2, newshift;
+  this->getMinMax3D(&p1, &p2);
+  newshift = (p1 + p2) / 2.0;
+  for(size_t i=0; i < points.size(); i++){
+    points[i] = points[i] - newshift;
+  }
+  shift = shift + newshift;
+}
+
+// mean value of all points (center of gravity)
+Vector3d PointCloud::meanValue() const {
+  Vector3d ret;
+  for(size_t i = 0; i < points.size(); i++){
+    ret = ret + points[i];
+  }
+  if (points.size() > 0)
+    return (ret / (double)points.size());
+  else
+    return ret;
+}
+
+// bounding box corners
+void PointCloud::getMinMax3D(Vector3d* min_pt, Vector3d* max_pt){
+  if(points.size() > 0){
+    *min_pt = points[0];
+    *max_pt = points[0];
+
+    for(std::vector<Vector3d>::iterator it = points.begin(); it != points.end(); it++){
+      if(min_pt->x > it->x) min_pt->x = it->x;
+      if(min_pt->y > it->y) min_pt->y = it->y;
+      if(min_pt->z > it->z) min_pt->z = it->z;
+
+      if(max_pt->x < (*it).x) max_pt->x = (*it).x;
+      if(max_pt->y < (*it).y) max_pt->y = (*it).y;
+      if(max_pt->z < (*it).z) max_pt->z = (*it).z;
+    }
+  } else {
+    *min_pt = Vector3d(0,0,0);
+    *max_pt = Vector3d(0,0,0);
+  }
+}
+
+// reads point cloud data from the given file
+// (see IPOL paper for file format)
+int PointCloud::readFromFile(const char* path){
+  FILE* f = fopen(path, "r");
+  if (!f) return 1;
+
+  char line[1024];
+  Vector3d point;
+  int n;
+  while (fgets(line, 1023, f)) {
+    if (line[0] == '#') continue;
+    n = sscanf(line, "%lf,%lf,%lf", &point.x, &point.y, &point.z);
+    if (n != 3) {
+      fclose(f);
+      return 2;
+    }
+    points.push_back(point);
+#ifdef WEBDEMO
+    if (points.size() > 1E6) {
+      fprintf(stderr, "Error: program was compiled in WEBDEMO mode, "
+              "which only permits less than 10^6 points in point cloud\n");
+      return 3;
+  }
+#endif
+  }
+
+  fclose(f);
+  return 0;
+}
+
+// store points closer than dx to line (a, b) in Y
+void PointCloud::pointsCloseToLine(const Vector3d &a, const Vector3d &b, double dx, PointCloud* Y) {
+
+  Y->points.clear();
+  for (size_t i=0; i < points.size(); i++) {
+    // distance computation after IPOL paper Eq. (7)
+    double t = (b * (points[i] - a));
+    Vector3d d = (points[i] - (a + (t*b)));
+    if (d.norm() <= dx) {
+      Y->points.push_back(points[i]);
+    }
+  }
+}
+
+// removes the points in Y from PointCloud
+// WARNING: only works when points in same order as in pointCloud!
+void PointCloud::removePoints(const PointCloud &Y){
+
+  if (Y.points.empty()) return;
+  std::vector<Vector3d> newpoints;
+  size_t i,j;
+
+  // important assumption: points in Y appear in same order in points
+  for (i = 0, j = 0; i < points.size() && j < Y.points.size(); i++){
+    if (points[i] == Y.points[j]) {
+      j++;
+    } else {
+      newpoints.push_back(points[i]);
+    }
+  }
+  // copy over rest after end of Y
+  for (; i < points.size(); i++)
+    newpoints.push_back(points[i]);
+
+  points = newpoints;
+}

--- a/Tracker/hough3d/pointcloud.cpp
+++ b/Tracker/hough3d/pointcloud.cpp
@@ -32,7 +32,7 @@ Vector3d PointCloud::meanValue() const {
     ret = ret + points[i];
   }
   if (points.size() > 0)
-    return (ret / (double)points.size());
+    return (ret / (track_t)points.size());
   else
     return ret;
 }
@@ -89,12 +89,12 @@ int PointCloud::readFromFile(const char* path){
 }
 
 // store points closer than dx to line (a, b) in Y
-void PointCloud::pointsCloseToLine(const Vector3d &a, const Vector3d &b, double dx, PointCloud* Y) {
+void PointCloud::pointsCloseToLine(const Vector3d &a, const Vector3d &b, track_t dx, PointCloud* Y) {
 
   Y->points.clear();
   for (size_t i=0; i < points.size(); i++) {
     // distance computation after IPOL paper Eq. (7)
-    double t = (b * (points[i] - a));
+    track_t t = (b * (points[i] - a));
     Vector3d d = (points[i] - (a + (t*b)));
     if (d.norm() <= dx) {
       Y->points.push_back(points[i]);

--- a/Tracker/hough3d/pointcloud.h
+++ b/Tracker/hough3d/pointcloud.h
@@ -1,0 +1,42 @@
+//
+// pointcloud.h
+//     Class for holding a set of 3D points
+//
+// Author:  Tilman Schramke, Christoph Dalitz
+// Date:    2017-03-16
+// License: see LICENSE-BSD2
+//
+
+#ifndef POINTCLOUD_H_
+#define POINTCLOUD_H_
+
+#include "vector3d.h"
+#include <vector>
+#include <string>
+
+class PointCloud {
+public:
+  // translation of pointCloud as done by shiftToOrigin()
+  Vector3d shift;
+  // points of the point cloud
+  std::vector<Vector3d> points;
+
+  // translate point cloud so that center = origin
+  void shiftToOrigin();
+  // mean value of all points (center of gravity)
+  Vector3d meanValue() const;
+  // bounding box corners
+  void getMinMax3D(Vector3d* min_pt, Vector3d* max_pt);
+  // reads point cloud data from the given file
+  int readFromFile(const char* path);
+  // store points closer than dx to line (a, b) in Y
+  void pointsCloseToLine(const Vector3d &a, const Vector3d &b,
+                         double dx, PointCloud* Y);
+  // removes the points in Y from PointCloud
+  // WARNING: only works when points in same order as in pointCloud!
+  void removePoints(const PointCloud &Y);
+};
+
+
+
+#endif /* POINTCLOUD_H_ */

--- a/Tracker/hough3d/pointcloud.h
+++ b/Tracker/hough3d/pointcloud.h
@@ -31,7 +31,7 @@ public:
   int readFromFile(const char* path);
   // store points closer than dx to line (a, b) in Y
   void pointsCloseToLine(const Vector3d &a, const Vector3d &b,
-                         double dx, PointCloud* Y);
+                         track_t dx, PointCloud* Y);
   // removes the points in Y from PointCloud
   // WARNING: only works when points in same order as in pointCloud!
   void removePoints(const PointCloud &Y);

--- a/Tracker/hough3d/sphere.cpp
+++ b/Tracker/hough3d/sphere.cpp
@@ -1,0 +1,333 @@
+//
+// sphere.cpp
+//     Class that implements direction quantization as described in
+//     Jeltsch, Dalitz, Pohle-Froehlich: "Hough Parameter Space
+//     Regularisation for Line Detection in 3D." VISAPP, pp. 345-352, 2016 
+//
+// Author:  Manuel Jeltsch, Tilman Schramke, Christoph Dalitz
+// Date:    2017-03-16
+// License: see LICENSE-BSD2
+//
+
+#include "sphere.h"
+
+#include <math.h>
+
+
+// creates the directions by subdivisions of icosahedron
+void Sphere::fromIcosahedron(int subDivisions){
+  this->getIcosahedron();
+  for(int i = 0; i < subDivisions; i++) {
+    subDivide();
+  }
+  this->makeUnique();
+}
+
+  // creates nodes and edges of icosahedron
+void Sphere::getIcosahedron(){
+  vertices.clear();
+  triangles.clear();
+  float tau = 1.61803399; // golden_ratio
+  float norm = sqrt(1 + tau * tau);
+  float v = 1 / norm;
+  tau = tau / norm;
+
+  Vector3d vec;
+  vec.x = -v;
+  vec.y = tau;
+  vec.z = 0;
+  vertices.push_back(vec); // 1
+  vec.x = v;
+  vec.y = tau;
+  vec.z = 0;
+  vertices.push_back(vec); // 2
+  vec.x = 0;
+  vec.y = v;
+  vec.z = -tau;
+  vertices.push_back(vec); // 3
+  vec.x = 0;
+  vec.y = v;
+  vec.z = tau;
+  vertices.push_back(vec); // 4
+  vec.x = -tau;
+  vec.y = 0;
+  vec.z = -v;
+  vertices.push_back(vec); // 5
+  vec.x = tau;
+  vec.y = 0;
+  vec.z = -v;
+  vertices.push_back(vec); // 6
+  vec.x = -tau;
+  vec.y = 0;
+  vec.z = v;
+  vertices.push_back(vec); // 7
+  vec.x = tau;
+  vec.y = 0;
+  vec.z = v;
+  vertices.push_back(vec); // 8
+  vec.x = 0;
+  vec.y = -v;
+  vec.z = -tau;
+  vertices.push_back(vec); // 9
+  vec.x = 0;
+  vec.y = -v;
+  vec.z = tau;
+  vertices.push_back(vec); // 10
+  vec.x = -v;
+  vec.y = -tau;
+  vec.z = 0;
+  vertices.push_back(vec); // 11
+  vec.x = v;
+  vec.y = -tau;
+  vec.z = 0;
+  vertices.push_back(vec); // 12
+  // add all edges of all triangles
+  triangles.push_back(0);
+  triangles.push_back(1);
+  triangles.push_back(2); // 1
+  triangles.push_back(0);
+  triangles.push_back(1);
+  triangles.push_back(3); // 2
+  triangles.push_back(0);
+  triangles.push_back(2);
+  triangles.push_back(4); // 3
+  triangles.push_back(0);
+  triangles.push_back(4);
+  triangles.push_back(6); // 4
+  triangles.push_back(0);
+  triangles.push_back(3);
+  triangles.push_back(6); // 5
+  triangles.push_back(1);
+  triangles.push_back(2);
+  triangles.push_back(5); // 6
+  triangles.push_back(1);
+  triangles.push_back(3);
+  triangles.push_back(7); // 7
+  triangles.push_back(1);
+  triangles.push_back(5);
+  triangles.push_back(7); // 8
+  triangles.push_back(2);
+  triangles.push_back(4);
+  triangles.push_back(8); // 9
+  triangles.push_back(2);
+  triangles.push_back(5);
+  triangles.push_back(8); // 10
+  triangles.push_back(3);
+  triangles.push_back(6);
+  triangles.push_back(9); // 1
+  triangles.push_back(3);
+  triangles.push_back(7);
+  triangles.push_back(9); // 12
+  triangles.push_back(4);
+  triangles.push_back(8);
+  triangles.push_back(10); // 13
+  triangles.push_back(8);
+  triangles.push_back(10);
+  triangles.push_back(11); // 14
+  triangles.push_back(5);
+  triangles.push_back(8);
+  triangles.push_back(11); // 15
+  triangles.push_back(5);
+  triangles.push_back(7);
+  triangles.push_back(11); // 16
+  triangles.push_back(7);
+  triangles.push_back(9);
+  triangles.push_back(11); // 17
+  triangles.push_back(9);
+  triangles.push_back(10);
+  triangles.push_back(11); // 18
+  triangles.push_back(6);
+  triangles.push_back(9);
+  triangles.push_back(10); // 19
+  triangles.push_back(4);
+  triangles.push_back(6);
+  triangles.push_back(10); // 20
+}
+
+// one subdivision step
+void Sphere::subDivide(){
+  unsigned int vert_num = vertices.size();
+  double norm;
+  // subdivide each triangle
+  int num = triangles.size() / 3;
+  for(int i = 0; i < num; i++) {
+    Vector3d a, b, c, d, e, f;
+
+    unsigned int ai, bi, ci, di, ei, fi;
+    ai = triangles.front();
+    triangles.pop_front();
+    bi = triangles.front();
+    triangles.pop_front();
+    ci = triangles.front();
+    triangles.pop_front();
+
+    a = vertices[ai];
+    b = vertices[bi];
+    c = vertices[ci];
+
+    //  d = a+b
+    d.x = (a.x + b.x);
+    d.y = (a.y + b.y);
+    d.z = (a.z + b.z);
+    norm = sqrt(d.x * d.x + d.y * d.y + d.z * d.z);
+    d.x /= norm;
+    d.y /= norm;
+    d.z /= norm;
+    //  e = b+c
+    e.x = (c.x + b.x);
+    e.y = (c.y + b.y);
+    e.z = (c.z + b.z);
+    norm = sqrt(e.x * e.x + e.y * e.y + e.z * e.z);
+    e.x /= norm;
+    e.y /= norm;
+    e.z /= norm;
+    //  f = c+a
+    f.x = (a.x + c.x);
+    f.y = (a.y + c.y);
+    f.z = (a.z + c.z);
+    norm = sqrt(f.x * f.x + f.y * f.y + f.z * f.z);
+    f.x /= norm;
+    f.y /= norm;
+    f.z /= norm;
+
+    // add all new edge indices of new triangles to the triangles deque
+    bool d_found = false;
+    bool e_found = false;
+    bool f_found = false;
+    for(unsigned int j = vert_num; j < vertices.size(); j++) {
+      if(vertices[j] == d) {
+        d_found = true;
+        di = j;
+        continue;
+      }
+      if(vertices[j] == e) {
+        e_found = true;
+        ei = j;
+        continue;
+      }
+      if(vertices[j] == f) {
+        f_found = true;
+        fi = j;
+        continue;
+      }
+
+    }
+    if(!d_found) {
+      di = vertices.size();
+      vertices.push_back(d);
+    }
+    if(!e_found) {
+      ei = vertices.size();
+      vertices.push_back(e);
+    }
+    if(!f_found) {
+      fi = vertices.size();
+      vertices.push_back(f);
+    }
+
+    triangles.push_back(ai);
+    triangles.push_back(di);
+    triangles.push_back(fi);
+
+    triangles.push_back(di);
+    triangles.push_back(bi);
+    triangles.push_back(ei);
+
+    triangles.push_back(fi);
+    triangles.push_back(ei);
+    triangles.push_back(ci);
+
+    triangles.push_back(fi);
+    triangles.push_back(di);
+    triangles.push_back(ei);
+  }
+}
+
+// make vectors nondirectional and unique
+void Sphere::makeUnique(){
+  for(unsigned int i = 0; i < vertices.size(); i++) {
+    if(vertices[i].z < 0) { // make hemisphere
+      vertices.erase(vertices.begin() + i);
+
+      // delete all triangles with vertex_i
+      int t = 0;
+      for(std::deque<unsigned int>::iterator it = triangles.begin();
+          it != triangles.end();) {
+        if(triangles[t] == i || triangles[t + 1] == i ||
+           triangles[t + 2] == i) {
+          it = triangles.erase(it);
+          it = triangles.erase(it);
+          it = triangles.erase(it);
+        } else {
+          ++it;
+          ++it;
+          ++it;
+          t += 3;
+        }
+      }
+      // update indices
+      for(unsigned int j = 0; j < triangles.size(); j ++) {
+        if(triangles[j] > i) {
+          triangles[j]--;
+        }
+      }
+
+      i--;
+    } else if(vertices[i].z == 0) { // make equator vectors unique
+      if(vertices[i].x < 0) {
+        vertices.erase(vertices.begin() + i);
+        // delete all triangles with vertex_i
+        int t = 0;
+        for(std::deque<unsigned int>::iterator it = triangles.begin();
+            it != triangles.end();) {
+          if(triangles[t] == i || triangles[t + 1] == i ||
+             triangles[t + 2] == i) {
+            it = triangles.erase(it);
+            it = triangles.erase(it);
+            it = triangles.erase(it);
+          } else {
+            ++it;
+            ++it;
+            ++it;
+            t += 3;
+          }
+        }
+        // update indices
+        for(unsigned int j = 0; j < triangles.size(); j ++) {
+          if(triangles[j] > i) {
+            triangles[j]--;
+          }
+        }
+        i--;
+      } else if(vertices[i].x == 0 && vertices[i].y == -1) {
+        vertices.erase(vertices.begin() + i);
+        // delete all triangles with vertex_i
+        int t = 0;
+        for(std::deque<unsigned int>::iterator it = triangles.begin();
+            it != triangles.end();) {
+          if(triangles[t] == i || triangles[t + 1] == i ||
+             triangles[t + 2] == i) {
+            it = triangles.erase(it);
+            it = triangles.erase(it);
+            it = triangles.erase(it);
+          } else {
+            ++it;
+            ++it;
+            ++it;
+            t += 3;
+          }
+        }
+        // update indices
+        for(unsigned int j = 0; j < triangles.size(); j ++) {
+          if(triangles[j] > i) {
+            triangles[j]--;
+          }
+        }
+        i--;
+      }
+    }
+  }
+}
+
+
+

--- a/Tracker/hough3d/sphere.cpp
+++ b/Tracker/hough3d/sphere.cpp
@@ -147,7 +147,7 @@ void Sphere::getIcosahedron(){
 // one subdivision step
 void Sphere::subDivide(){
   unsigned int vert_num = vertices.size();
-  double norm;
+  track_t norm;
   // subdivide each triangle
   int num = triangles.size() / 3;
   for(int i = 0; i < num; i++) {

--- a/Tracker/hough3d/sphere.cpp
+++ b/Tracker/hough3d/sphere.cpp
@@ -27,7 +27,7 @@ void Sphere::fromIcosahedron(int subDivisions){
 void Sphere::getIcosahedron(){
   vertices.clear();
   triangles.clear();
-  float tau = 1.61803399; // golden_ratio
+  float tau = 1.61803399f; // golden_ratio
   float norm = sqrt(1 + tau * tau);
   float v = 1 / norm;
   tau = tau / norm;

--- a/Tracker/hough3d/sphere.h
+++ b/Tracker/hough3d/sphere.h
@@ -1,0 +1,39 @@
+//
+// sphere.h
+//     Class that implements direction quantization as described in
+//     Jeltsch, Dalitz, Pohle-Froehlich: "Hough Parameter Space
+//     Regularisation for Line Detection in 3D." VISAPP, pp. 345-352, 2016 
+//
+// Author:  Manuel Jeltsch, Tilman Schramke
+// Date:    2017-03-16
+// License: see LICENSE-BSD2
+//
+
+#ifndef SPHERE_H_
+#define SPHERE_H_
+
+#include "vector3d.h"
+#include <vector>
+#include <deque>
+
+class Sphere {
+
+public:
+  // direction vectors
+  std::vector<Vector3d> vertices;
+  // surface triangles
+  std::deque<unsigned int> triangles;
+  // creates the directions by subdivisions of icosahedron
+  void fromIcosahedron(int subDivisions=4);
+
+private:
+  // creates nodes and edges of icosahedron
+  void getIcosahedron();
+  // one subdivision step
+  void subDivide();
+  // make vectors nondirectional and unique
+  void makeUnique();
+
+};
+
+#endif /* SPHERE_H_ */

--- a/Tracker/hough3d/vector3d.cpp
+++ b/Tracker/hough3d/vector3d.cpp
@@ -1,0 +1,73 @@
+//
+// vector3d.cpp
+//     Class providing common math operations for 3D points
+//
+// Author:  Tilman Schramke, Christoph Dalitz
+// Date:    2017-03-16
+// License: see LICENSE-BSD2
+//
+
+#include "vector3d.h"
+#include <math.h>
+
+Vector3d::Vector3d() {
+  x = 0; y = 0; z = 0;
+}
+
+Vector3d::Vector3d(double a, double b, double c) {
+  x = a; y = b; z = c;
+}
+
+bool Vector3d::operator==(const Vector3d &rhs) const {
+  if((x == rhs.x) && (y == rhs.y) && (z == rhs.z))
+    return true;
+  return false;
+}
+
+Vector3d& Vector3d::operator=(const Vector3d& other) {
+  x = other.x; y = other.y; z = other.z;
+  return *this;
+}
+
+// nicely formatted output
+std::ostream& operator<<(std::ostream& strm, const Vector3d& vec) {
+  return strm << "(" << vec.x << "," << vec.y << "," << vec.z << ")";
+}
+
+// Euclidean norm
+double Vector3d::norm() const {
+  return sqrt((x * x) + (y * y) + (z * z));
+}
+
+// mathematical vector operations
+
+// vector addition
+Vector3d operator+(Vector3d x, Vector3d y) {
+  Vector3d v(x.x + y.x, x.y + y.y, x.z + y.z);
+  return v;
+}
+
+// vector subtraction
+Vector3d operator-(Vector3d x, Vector3d y) {
+  Vector3d v(x.x - y.x, x.y - y.y, x.z - y.z);
+  return v;
+}
+
+// scalar product
+double operator*(Vector3d x, Vector3d y) {
+  return (x.x*y.x + x.y*y.y +  x.z*y.z);
+}
+
+// scalar multiplication
+Vector3d operator*(Vector3d x, double c) {
+  Vector3d v(c*x.x, c*x.y, c*x.z);
+  return v;
+}
+Vector3d operator*(double c, Vector3d x) {
+  Vector3d v(c*x.x, c*x.y, c*x.z);
+  return v;
+}
+Vector3d operator/(Vector3d x, double c) {
+  Vector3d v(x.x/c, x.y/c, x.z/c);
+  return v;
+}

--- a/Tracker/hough3d/vector3d.cpp
+++ b/Tracker/hough3d/vector3d.cpp
@@ -14,7 +14,7 @@ Vector3d::Vector3d() {
   x = 0; y = 0; z = 0;
 }
 
-Vector3d::Vector3d(double a, double b, double c) {
+Vector3d::Vector3d(track_t a, track_t b, track_t c) {
   x = a; y = b; z = c;
 }
 
@@ -31,11 +31,11 @@ Vector3d& Vector3d::operator=(const Vector3d& other) {
 
 // nicely formatted output
 std::ostream& operator<<(std::ostream& strm, const Vector3d& vec) {
-  return strm << "(" << vec.x << "," << vec.y << "," << vec.z << ")";
+  return strm << "(" << vec.x << ", " << vec.y << ", " << vec.z << ")";
 }
 
 // Euclidean norm
-double Vector3d::norm() const {
+track_t Vector3d::norm() const {
   return sqrt((x * x) + (y * y) + (z * z));
 }
 
@@ -54,20 +54,20 @@ Vector3d operator-(Vector3d x, Vector3d y) {
 }
 
 // scalar product
-double operator*(Vector3d x, Vector3d y) {
+track_t operator*(Vector3d x, Vector3d y) {
   return (x.x*y.x + x.y*y.y +  x.z*y.z);
 }
 
 // scalar multiplication
-Vector3d operator*(Vector3d x, double c) {
+Vector3d operator*(Vector3d x, track_t c) {
   Vector3d v(c*x.x, c*x.y, c*x.z);
   return v;
 }
-Vector3d operator*(double c, Vector3d x) {
+Vector3d operator*(track_t c, Vector3d x) {
   Vector3d v(c*x.x, c*x.y, c*x.z);
   return v;
 }
-Vector3d operator/(Vector3d x, double c) {
+Vector3d operator/(Vector3d x, track_t c) {
   Vector3d v(x.x/c, x.y/c, x.z/c);
   return v;
 }

--- a/Tracker/hough3d/vector3d.h
+++ b/Tracker/hough3d/vector3d.h
@@ -1,0 +1,46 @@
+//
+// vector3d.h
+//     Class providing common math operations for 3D points
+//
+// Author:  Tilman Schramke, Christoph Dalitz
+// Date:    2017-03-16
+// License: see LICENSE-BSD2
+//
+
+#ifndef VECTOR3D_H_
+#define VECTOR3D_H_
+
+#include <iostream>
+
+class Vector3d {
+public:
+  double x;
+  double y;
+  double z;
+
+  Vector3d();
+  Vector3d(double a, double b, double c);
+  bool operator==(const Vector3d &rhs) const;
+  Vector3d& operator=(const Vector3d& other);
+  // nicely formatted output
+  friend std::ostream& operator<<(std::ostream& os, const Vector3d& vec);
+  // Euclidean norm
+  double norm() const;
+
+};
+
+// mathematical vector operations
+
+// vector addition
+Vector3d operator+(Vector3d x, Vector3d y);
+// vector subtraction
+Vector3d operator-(Vector3d x, Vector3d y);
+// scalar product
+double operator*(Vector3d x, Vector3d y);
+// scalar multiplication
+Vector3d operator*(Vector3d x, double c);
+Vector3d operator*(double c, Vector3d x);
+Vector3d operator/(Vector3d x, double c);
+
+
+#endif /* VECTOR3D_H_ */

--- a/Tracker/hough3d/vector3d.h
+++ b/Tracker/hough3d/vector3d.h
@@ -11,21 +11,23 @@
 #define VECTOR3D_H_
 
 #include <iostream>
+#include "defines.h"
 
-class Vector3d {
+class Vector3d
+{
 public:
-  double x;
-  double y;
-  double z;
+  track_t x;
+  track_t y;
+  track_t z;
 
   Vector3d();
-  Vector3d(double a, double b, double c);
+  Vector3d(track_t a, track_t b, track_t c);
   bool operator==(const Vector3d &rhs) const;
   Vector3d& operator=(const Vector3d& other);
   // nicely formatted output
   friend std::ostream& operator<<(std::ostream& os, const Vector3d& vec);
   // Euclidean norm
-  double norm() const;
+  track_t norm() const;
 
 };
 
@@ -36,11 +38,11 @@ Vector3d operator+(Vector3d x, Vector3d y);
 // vector subtraction
 Vector3d operator-(Vector3d x, Vector3d y);
 // scalar product
-double operator*(Vector3d x, Vector3d y);
+track_t operator*(Vector3d x, Vector3d y);
 // scalar multiplication
-Vector3d operator*(Vector3d x, double c);
-Vector3d operator*(double c, Vector3d x);
-Vector3d operator/(Vector3d x, double c);
+Vector3d operator*(Vector3d x, track_t c);
+Vector3d operator*(track_t c, Vector3d x);
+Vector3d operator/(Vector3d x, track_t c);
 
 
 #endif /* VECTOR3D_H_ */

--- a/Tracker/track.cpp
+++ b/Tracker/track.cpp
@@ -79,8 +79,8 @@ track_t CTrack::CalcDistJaccard(const cv::Rect& r) const
 {
     cv::Rect rr(GetLastRect());
 
-    track_t intArea = (r & rr).area();
-    track_t unionArea = r.area() + rr.area() - intArea;
+	track_t intArea = static_cast<track_t>((r & rr).area());
+	track_t unionArea = static_cast<track_t>(r.area() + rr.area() - intArea);
 
     return 1 - intArea / unionArea;
 }
@@ -346,7 +346,7 @@ void CTrack::CreateExternalTracker()
             params.desc_pca = cv::TrackerKCF::GRAY;
             params.desc_npca = cv::TrackerKCF::GRAY;
             params.resize = true;
-            params.detect_thresh = 0.3;
+            params.detect_thresh = 0.3f;
 #if (((CV_VERSION_MAJOR == 3) && (CV_VERSION_MINOR >= 3)) || (CV_VERSION_MAJOR > 3))
             m_tracker = cv::TrackerKCF::create(params);
 #else
@@ -406,7 +406,7 @@ void CTrack::CreateExternalTracker()
         if (!m_tracker || m_tracker.empty())
         {
 #if (((CV_VERSION_MAJOR == 3) && (CV_VERSION_MINOR >= 3)) || (CV_VERSION_MAJOR > 3))
-            m_tracker = cv::TrackerMOSSE::create();
+            //m_tracker = cv::TrackerMOSSE::create();
 #else
             m_tracker = cv::TrackerMOSSE::createTracker();
 #endif
@@ -445,7 +445,7 @@ void CTrack::PointUpdate(
         m_predictionPoint = m_kalman->Update(pt, dataCorrect);
     }
 
-    auto Clamp = [](float& v, int hi)
+	auto Clamp = [](track_t& v, int hi)
     {
         if (v < 0)
         {
@@ -453,7 +453,7 @@ void CTrack::PointUpdate(
         }
         else if (hi && v > hi - 1)
         {
-            v = hi - 1;
+			v = static_cast<track_t>(hi - 1);
         }
     };
     Clamp(m_predictionPoint.x, frameSize.width);

--- a/Tracker/track.cpp
+++ b/Tracker/track.cpp
@@ -246,6 +246,7 @@ void CTrack::RectUpdate(
             Clamp(roiRect.x, roiRect.width, currFrame.cols);
             Clamp(roiRect.y, roiRect.height, currFrame.rows);
 
+            bool inited = false;
             if (!m_tracker || m_tracker.empty())
             {
                 CreateExternalTracker();
@@ -258,6 +259,13 @@ void CTrack::RectUpdate(
                         lastRect.area() > 0)
                 {
                     m_tracker->init(cv::UMat(prevFrame, roiRect), lastRect);
+#if 0
+                    cv::Mat tmp = cv::UMat(prevFrame, roiRect).getMat(cv::ACCESS_READ).clone();
+                    cv::rectangle(tmp, lastRect, cv::Scalar(255, 255, 255), 2);
+                    cv::imshow("init", tmp);
+#endif
+
+                    inited = true;
                 }
                 else
                 {
@@ -265,8 +273,14 @@ void CTrack::RectUpdate(
                 }
             }
             cv::Rect2d newRect;
-            if (!m_tracker.empty() && m_tracker->update(cv::UMat(currFrame, roiRect), newRect))
+            if (!inited && !m_tracker.empty() && m_tracker->update(cv::UMat(currFrame, roiRect), newRect))
             {
+#if 0
+                cv::Mat tmp2 = cv::UMat(currFrame, roiRect).getMat(cv::ACCESS_READ).clone();
+                cv::rectangle(tmp2, newRect, cv::Scalar(255, 255, 255), 2);
+                cv::imshow("track", tmp2);
+#endif
+
                 cv::Rect prect(cvRound(newRect.x) + roiRect.x, cvRound(newRect.y) + roiRect.y, cvRound(newRect.width), cvRound(newRect.height));
 
                 m_predictionRect = m_kalman->Update(prect, true);

--- a/Tracker/track.cpp
+++ b/Tracker/track.cpp
@@ -346,7 +346,7 @@ void CTrack::CreateExternalTracker()
             params.desc_pca = cv::TrackerKCF::GRAY;
             params.desc_npca = cv::TrackerKCF::GRAY;
             params.resize = true;
-            params.detect_thresh = 0.3f;
+            params.detect_thresh = 0.5f;
 #if (((CV_VERSION_MAJOR == 3) && (CV_VERSION_MINOR >= 3)) || (CV_VERSION_MAJOR > 3))
             m_tracker = cv::TrackerKCF::create(params);
 #else

--- a/VideoExample.h
+++ b/VideoExample.h
@@ -63,7 +63,7 @@ public:
 
         capture.set(cv::CAP_PROP_POS_FRAMES, m_startFrame);
 
-        m_fps = std::max(1, cvRound(capture.get(cv::CAP_PROP_FPS)));
+        m_fps = std::max(1.f, (float)capture.get(cv::CAP_PROP_FPS));
 
         capture >> frame;
         cv::cvtColor(frame, gray, cv::COLOR_BGR2GRAY);
@@ -108,7 +108,7 @@ public:
 
             cv::imshow("Video", frame);
 
-            int waitTime = manualMode ? 0 : std::max<int>(1, 1000 / m_fps - currTime);
+            int waitTime = manualMode ? 0 : std::max<int>(1, cvRound(1000 / m_fps - currTime));
             k = cv::waitKey(waitTime);
 
             if (k == 'm' || k == 'M')
@@ -159,13 +159,13 @@ protected:
 
         const regions_t& regions = m_detector->GetDetects();
 
-        m_tracker->Update(regions, m_tracker->GrayFrameToTrack() ? grayFrame : clFrame);
+        m_tracker->Update(regions, m_tracker->GrayFrameToTrack() ? grayFrame : clFrame, m_fps);
     }
 
     virtual void DrawData(cv::Mat frame, int framesCounter, int currTime) = 0;
 
     bool m_showLogs;
-    int m_fps;
+    float m_fps;
     bool m_useLocalTracking;
 
     ///
@@ -521,7 +521,7 @@ protected:
             regions.push_back(rect);
         }
 
-        m_tracker->Update(regions, grayFrame);
+        m_tracker->Update(regions, grayFrame, m_fps);
     }
 
     ///

--- a/VideoExample.h
+++ b/VideoExample.h
@@ -176,7 +176,8 @@ protected:
     ///
     void DrawTrack(cv::Mat frame,
                    int resizeCoeff,
-                   const CTrack& track
+                   const CTrack& track,
+                   bool drawTrajectory = true
                    )
     {
         auto ResizeRect = [&](const cv::Rect& r) -> cv::Rect
@@ -190,17 +191,20 @@ protected:
 
         cv::rectangle(frame, ResizeRect(track.GetLastRect()), cv::Scalar(0, 255, 0), 1, CV_AA);
 
-        cv::Scalar cl = m_colors[track.m_trackID % m_colors.size()];
-
-        for (size_t j = 0; j < track.m_trace.size() - 1; ++j)
+        if (drawTrajectory)
         {
-            const TrajectoryPoint& pt1 = track.m_trace.at(j);
-            const TrajectoryPoint& pt2 = track.m_trace.at(j + 1);
+            cv::Scalar cl = m_colors[track.m_trackID % m_colors.size()];
 
-            cv::line(frame, ResizePoint(pt1.m_prediction), ResizePoint(pt2.m_prediction), cl, 1, CV_AA);
-            if (!pt2.m_hasRaw)
+            for (size_t j = 0; j < track.m_trace.size() - 1; ++j)
             {
-                cv::circle(frame, ResizePoint(pt2.m_prediction), 4, cl, 1, CV_AA);
+                const TrajectoryPoint& pt1 = track.m_trace.at(j);
+                const TrajectoryPoint& pt2 = track.m_trace.at(j + 1);
+
+                cv::line(frame, ResizePoint(pt1.m_prediction), ResizePoint(pt2.m_prediction), cl, 1, CV_AA);
+                if (!pt2.m_hasRaw)
+                {
+                    cv::circle(frame, ResizePoint(pt2.m_prediction), 4, cl, 1, CV_AA);
+                }
             }
         }
     }

--- a/VideoExample.h
+++ b/VideoExample.h
@@ -581,7 +581,8 @@ protected:
         BaseDetector::config_t config;
         config["modelConfiguration"] = "../data/MobileNetSSD_deploy.prototxt";
         config["modelBinary"] = "../data/MobileNetSSD_deploy.caffemodel";
-        config["confidenceThreshold"] = "0.2";
+        config["confidenceThreshold"] = "0.5";
+        config["maxCropRatio"] = "3.0";
         m_detector = std::unique_ptr<BaseDetector>(CreateDetector(tracking::Detectors::DNN, config, m_useLocalTracking, frame));
         if (!m_detector.get())
         {
@@ -619,7 +620,7 @@ protected:
         for (const auto& track : m_tracker->tracks)
         {
             if (track->IsRobust(5,                           // Minimal trajectory size
-                                0.5f,                        // Minimal ratio raw_trajectory_points / trajectory_lenght
+                                0.2f,                        // Minimal ratio raw_trajectory_points / trajectory_lenght
                                 cv::Size2f(0.1f, 8.0f))      // Min and max ratio: width / height
                     )
             {
@@ -634,7 +635,7 @@ protected:
             }
         }
 
-        m_detector->CalcMotionMap(frame);
+        //m_detector->CalcMotionMap(frame);
     }
 
     ///

--- a/VideoExample.h
+++ b/VideoExample.h
@@ -271,7 +271,7 @@ protected:
 
         for (const auto& track : m_tracker->tracks)
         {
-            if (track->IsRobust(m_fps / 2,                         // Minimal trajectory size
+            if (track->IsRobust(cvRound(m_fps / 2),          // Minimal trajectory size
                                 0.6f,                        // Minimal ratio raw_trajectory_points / trajectory_lenght
                                 cv::Size2f(0.1f, 8.0f))      // Min and max ratio: width / height
                     )
@@ -422,7 +422,7 @@ protected:
 
         for (const auto& track : m_tracker->tracks)
         {
-            if (track->IsRobust(m_fps / 2,                   // Minimal trajectory size
+			if (track->IsRobust(cvRound(m_fps / 2),          // Minimal trajectory size
                                 0.4f,                        // Minimal ratio raw_trajectory_points / trajectory_lenght
                                 cv::Size2f(0.1f, 8.0f))      // Min and max ratio: width / height
                     )
@@ -513,7 +513,7 @@ protected:
         faceRects.insert(faceRects.end(), m_prevRects.begin(), m_prevRects.end());
         scores.insert(scores.end(), m_prevRects.size(), 0.4f);
         std::vector<cv::Rect> allRects;
-        nms2(faceRects, scores, allRects, 0.3f, 1, 0.7);
+        nms2(faceRects, scores, allRects, 0.3f, 1, 0.7f);
 
         regions_t regions;
         for (auto rect : allRects)

--- a/defines.h
+++ b/defines.h
@@ -72,6 +72,7 @@ enum DistType
     DistCenters = 0,
     DistRects = 1,
     DistJaccard = 2
+    //DistLines = 3
 };
 
 ///

--- a/nms.h
+++ b/nms.h
@@ -48,8 +48,8 @@ inline void nms(
             // grab the current rectangle
             const cv::Rect& rect2 = srcRects[pos->second];
 
-            float intArea = (rect1 & rect2).area();
-            float unionArea = rect1.area() + rect2.area() - intArea;
+			float intArea = static_cast<float>((rect1 & rect2).area());
+			float unionArea = static_cast<float>(rect1.area() + rect2.area() - intArea);
             float overlap = intArea / unionArea;
 
             // if there is sufficient overlap, suppress the current bounding box
@@ -122,8 +122,8 @@ inline void nms2(
             // grab the current rectangle
             const cv::Rect& rect2 = srcRects[pos->second];
 
-            float intArea = (rect1 & rect2).area();
-            float unionArea = rect1.area() + rect2.area() - intArea;
+			float intArea = static_cast<float>((rect1 & rect2).area());
+			float unionArea = static_cast<float>(rect1.area() + rect2.area() - intArea);
             float overlap = intArea / unionArea;
 
             // if there is sufficient overlap, suppress the current bounding box
@@ -199,8 +199,8 @@ inline void nms3(
             // grab the current rectangle
             const cv::Rect& rect2 = GetRect(srcRects[pos->second]);
 
-            float intArea = (rect1 & rect2).area();
-            float unionArea = rect1.area() + rect2.area() - intArea;
+			float intArea = static_cast<float>((rect1 & rect2).area());
+			float unionArea = static_cast<float>(rect1.area() + rect2.area() - intArea);
             float overlap = intArea / unionArea;
 
             // if there is sufficient overlap, suppress the current bounding box


### PR DESCRIPTION
1. New option config["maxCropRatio"] = "3.0" for DNN detector. Now MobileNetSSD works with 300x300 regions. If we have a high resolution video and small objects than it will can't be detected. maxCropRatio == 3 say than we use multiply crops 900x900.

2. Fixed a bug with KCF and another trackers.

3. Added new video example for the DNN detector for car DVR videos.

4. Some warnings remove and refactoring.

5. Added not completed hough3d algorithm for trajectories matching. I will complete this part in the near time.