### PR TITLE
Work with color frames by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Multitarget (multiple objects) tracker
 
-#### 1. Objects detector can be created with function [CreateDetector](https://github.com/Smorodov/Multitarget-tracker/blob/master/src/Detector/BaseDetector.cpp#L17) with different values of the detectorType:
+#### 1. Objects detector can be created with function [CreateDetector](https://github.com/Smorodov/Multitarget-tracker/blob/master/src/Detector/BaseDetector.cpp) with different values of the detectorType:
 
 1.1. Based on background substraction: built-in Vibe (tracking::Motion_VIBE), SuBSENSE (tracking::Motion_SuBSENSE) and LOBSTER (tracking::Motion_LOBSTER); MOG2 (tracking::Motion_MOG2) from [opencv](https://github.com/opencv/opencv/blob/master/modules/video/include/opencv2/video/background_segm.hpp); MOG (tracking::Motion_MOG), GMG (tracking::Motion_GMG) and CNT (tracking::Motion_CNT) from [opencv_contrib](https://github.com/opencv/opencv_contrib/tree/master/modules/bgsegm). For foreground segmentation used contours from OpenCV with result as cv::RotatedRect
 
@@ -18,27 +18,27 @@
 
 1.7. You can to use custom detector with bounding or rotated rectangle as output.
 
-#### 2. Matching or solve an [assignment problem](https://github.com/Smorodov/Multitarget-tracker/blob/master/src/Tracker/Ctracker.h#L23):
+#### 2. Matching or solve an [assignment problem](https://github.com/Smorodov/Multitarget-tracker/blob/master/src/Tracker/Ctracker.h):
 
 2.1. Hungrian algorithm (tracking::MatchHungrian) with cubic time O(N^3) where N is objects count
 
 2.2. Algorithm based on weighted bipartite graphs (tracking::MatchBipart) from [rdmpage](https://github.com/rdmpage/maximum-weighted-bipartite-matching) with time O(M * N^2) where N is objects count and M is connections count between detections on frame and tracking objects. It can be faster than Hungrian algorithm
 
-2.3. [Distance](https://github.com/Smorodov/Multitarget-tracker/blob/master/src/Tracker/Ctracker.h#L19) from detections and objects: euclidean distance in pixels between centers (tracking::DistCenters), euclidean distance in pixels between rectangles (tracking::DistRects), Jaccard or IoU distance from 0 to 1 (tracking::DistJaccard)
+2.3. [Distance](https://github.com/Smorodov/Multitarget-tracker/blob/master/src/Tracker/Ctracker.h) from detections and objects: euclidean distance in pixels between centers (tracking::DistCenters), euclidean distance in pixels between rectangles (tracking::DistRects), Jaccard or IoU distance from 0 to 1 (tracking::DistJaccard)
 
-#### 3. [Smoothing trajectories and predict missed objects](https://github.com/Smorodov/Multitarget-tracker/blob/master/src/Tracker/Ctracker.h#L20):
+#### 3. [Smoothing trajectories and predict missed objects](https://github.com/Smorodov/Multitarget-tracker/blob/master/src/Tracker/Ctracker.h):
 
 3.1. Linear Kalman filter from OpenCV (tracking::KalmanLinear)
 
 3.2. Unscented Kalman filter from OpenCV (tracking::KalmanUnscented)
 
-3.3. [Kalman goal](https://github.com/Smorodov/Multitarget-tracker/blob/master/src/Tracker/Ctracker.h#L21) is only coordinates (tracking::FilterCenter) or coordinates and size (tracking::FilterRect)
+3.3. [Kalman goal](https://github.com/Smorodov/Multitarget-tracker/blob/master/src/Tracker/Ctracker.h) is only coordinates (tracking::FilterCenter) or coordinates and size (tracking::FilterRect)
 
-3.4. Simple [Abandoned detector](https://github.com/Smorodov/Multitarget-tracker/blob/master/src/Tracker/Ctracker.h#L59)
+3.4. Simple [Abandoned detector](https://github.com/Smorodov/Multitarget-tracker/blob/master/src/Tracker/Ctracker.h)
 
-3.5. [Line intersection](https://github.com/Smorodov/Multitarget-tracker/blob/master/cars_counting/CarsCounting.cpp#L381) counting
+3.5. [Line intersection](https://github.com/Smorodov/Multitarget-tracker/blob/master/cars_counting/CarsCounting.cpp) counting
 
-#### 4. [Advanced visual search](https://github.com/Smorodov/Multitarget-tracker/blob/master/src/Tracker/Ctracker.h#L22) for objects if they have not been detected:
+#### 4. [Advanced visual search](https://github.com/Smorodov/Multitarget-tracker/blob/master/src/Tracker/Ctracker.h) for objects if they have not been detected:
 
 4.1. No search (tracking::TrackNone)
 
@@ -48,7 +48,7 @@ With this option the tracking can work match slower but more accuracy.
 
 #### 5. Pipeline
 
-5.1. Syncronous [pipeline - SyncProcess](https://github.com/Smorodov/Multitarget-tracker/blob/master/example/VideoExample.h#L77):
+5.1. Syncronous [pipeline - SyncProcess](https://github.com/Smorodov/Multitarget-tracker/blob/master/example/VideoExample.h):
 - get frame from capture device;
 - decoding;
 - objects detection (1);
@@ -57,7 +57,7 @@ With this option the tracking can work match slower but more accuracy.
 
 This pipeline is good if all algorithms are fast and works faster than time between two frames (40 ms for device with 25 fps). Or it can be used if we have only 1 core for all (no parallelization).
 
-5.2. Pipeline with [2 threads - AsyncProcess](https://github.com/Smorodov/Multitarget-tracker/blob/master/example/VideoExample.h#L77):
+5.2. Pipeline with [2 threads - AsyncProcess](https://github.com/Smorodov/Multitarget-tracker/blob/master/example/VideoExample.h):
 - 1th thread takes frame t and makes capture, decoding and objects detection;
 - 2th thread takes frame t-1, results from first thread and makes tracking and results presentation (this is the Main read).
 

--- a/TODO
+++ b/TODO
@@ -15,10 +15,7 @@ BGFG:
 2. Integration with new https://github.com/andrewssobral/bgslibrary
 
 Metrics between regions and tracking objects:
-1. Histograms
-2. HOG
-3. Caching results of hist and HOG
-4. Complex metric
+1. HOG
 
 New runtime:
 1. Integration with deepstream sdk 4.0

--- a/TODO
+++ b/TODO
@@ -10,3 +10,15 @@ Deep SORT:
 2. https://github.com/bitzy/DeepSort
 3. https://github.com/oylz/DS
 
+BGFG:
+1. Original Vibe
+2. Integration with new https://github.com/andrewssobral/bgslibrary
+
+Metrics between regions and tracking objects:
+1. Histograms
+2. HOG
+3. Caching results of hist and HOG
+4. Complex metric
+
+New runtime:
+1. Integration with deepstream sdk 4.0

--- a/TODO
+++ b/TODO
@@ -15,7 +15,13 @@ BGFG:
 2. Integration with new https://github.com/andrewssobral/bgslibrary
 
 Metrics between regions and tracking objects:
-1. HOG
+1. Profiling histograms
+2. HOG
+3. Normaliza pixels metric to [0, 1]
 
 New runtime:
 1. Integration with deepstream sdk 4.0
+
+Tests:
+1. Quality tests
+2. Performance tests

--- a/async_detector/AsyncDetector.h
+++ b/async_detector/AsyncDetector.h
@@ -20,7 +20,6 @@ struct FrameInfo
 {
 	cv::Mat m_frame;
     cv::UMat m_clFrame;
-	cv::UMat m_gray;
 	regions_t m_regions;
 	std::vector<TrackingObject> m_tracks;
 	int64 m_dt = 0;
@@ -63,6 +62,6 @@ private:
     void DrawTrack(cv::Mat frame, int resizeCoeff, const TrackingObject& track, bool drawTrajectory = true);
 
     static void CaptureThread(std::string fileName, int startFrame, float* fps, FramesQueue* framesQue, bool* stopFlag);
-    static void DetectThread(const config_t& config, cv::UMat firstGray, FramesQueue* framesQue, bool* stopFlag);
+    static void DetectThread(const config_t& config, cv::Mat firstFrame, FramesQueue* framesQue, bool* stopFlag);
 	static void TrackingThread(const TrackerSettings& settings, FramesQueue* framesQue, bool* stopFlag);
 };

--- a/cars_counting/CarsCounting.cpp
+++ b/cars_counting/CarsCounting.cpp
@@ -107,7 +107,7 @@ void CarsCounting::Process()
         int64 t1 = cv::getTickCount();
 
         cv::UMat uframe;
-        if (!m_detector->CanGrayProcessing() || !m_tracker->GrayFrameToTrack())
+        if (!m_detector->CanGrayProcessing() || m_tracker->CanColorFrameToTrack())
         {
             uframe = colorFrame.getUMat(cv::ACCESS_READ);
         }

--- a/cars_counting/CarsCounting.h
+++ b/cars_counting/CarsCounting.h
@@ -241,8 +241,6 @@ protected:
     bool m_showLogs = false;
     float m_fps = 0;
 
-    virtual bool GrayProcessing() const;
-
     virtual bool InitTracker(cv::UMat frame);
 
     virtual void DrawData(cv::Mat frame, int framesCounter, int currTime);

--- a/example/MouseExample.h
+++ b/example/MouseExample.h
@@ -47,7 +47,7 @@ void MouseTracking(cv::CommandLineParser parser)
 	cv::setMouseCallback("Video", mv_MouseCallback, (void*)&pointXY);
 
 	TrackerSettings settings;
-	settings.m_distType = tracking::DistCenters;
+	settings.SetDistances({ 1.0f, 0.0f, 0.0f, 0.0f, 0.0f });
 	settings.m_kalmanType = tracking::KalmanLinear;
 	settings.m_filterGoal = tracking::FilterCenter;
 	settings.m_lostTrackType = tracking::TrackNone;

--- a/example/VideoExample.cpp
+++ b/example/VideoExample.cpp
@@ -355,7 +355,7 @@ void VideoExample::Detection(cv::Mat frame, regions_t& regions)
 void VideoExample::Tracking(cv::Mat frame, const regions_t& regions)
 {
  	cv::UMat uframe;
-	if (!m_tracker->GrayFrameToTrack())
+	if (m_tracker->CanColorFrameToTrack())
 	{
 		uframe = frame.getUMat(cv::ACCESS_READ);
 	}

--- a/example/VideoExample.h
+++ b/example/VideoExample.h
@@ -41,13 +41,11 @@ protected:
 
     static void CaptureAndDetect(VideoExample* thisPtr, std::atomic<bool>& stopCapture);
 
-    virtual bool GrayProcessing() const;
-
     virtual bool InitDetector(cv::UMat frame) = 0;
     virtual bool InitTracker(cv::UMat frame) = 0;
 
-    void Detection(cv::Mat frame, cv::UMat grayFrame, regions_t& regions);
-    void Tracking(cv::Mat frame, cv::UMat grayFrame, const regions_t& regions);
+    void Detection(cv::Mat frame, regions_t& regions);
+    void Tracking(cv::Mat frame, const regions_t& regions);
 
     virtual void DrawData(cv::Mat frame, int framesCounter, int currTime) = 0;
 
@@ -67,7 +65,6 @@ private:
     struct FrameInfo
     {
         cv::Mat m_frame;
-        cv::UMat m_gray;
         regions_t m_regions;
         int64 m_dt = 0;
 

--- a/example/examples.h
+++ b/example/examples.h
@@ -60,14 +60,14 @@ protected:
     bool InitTracker(cv::UMat frame)
     {
         TrackerSettings settings;
-		settings.SetDistances({ 1.0f, 0.0f, 0.0f, 0.0f, 0.0f });
+		settings.SetDistances({ 0.0f, 0.0f, 0.5f, 0.5f, 0.0f });
         settings.m_kalmanType = tracking::KalmanLinear;
         settings.m_filterGoal = tracking::FilterRect;
-        settings.m_lostTrackType = tracking::TrackKCF;       // Use visual objects tracker for collisions resolving
+        settings.m_lostTrackType = tracking::TrackNone;       // Use visual objects tracker for collisions resolving
         settings.m_matchType = tracking::MatchHungrian;
         settings.m_dt = 0.4f;                             // Delta time for Kalman filter
         settings.m_accelNoiseMag = 0.5f;                  // Accel noise magnitude for Kalman filter
-        settings.m_distThres = frame.rows / 10.f;         // Distance threshold between region and object on two frames
+		settings.m_distThres = 0.6; // frame.rows / 10.f;         // Distance threshold between region and object on two frames
 
         settings.m_useAbandonedDetection = false;
         if (settings.m_useAbandonedDetection)

--- a/example/examples.h
+++ b/example/examples.h
@@ -60,7 +60,7 @@ protected:
     bool InitTracker(cv::UMat frame)
     {
         TrackerSettings settings;
-        settings.m_distType = tracking::DistCenters;
+		settings.SetDistances({ 1.0f, 0.0f, 0.0f, 0.0f, 0.0f });
         settings.m_kalmanType = tracking::KalmanLinear;
         settings.m_filterGoal = tracking::FilterRect;
         settings.m_lostTrackType = tracking::TrackKCF;       // Use visual objects tracker for collisions resolving
@@ -175,7 +175,7 @@ protected:
     bool InitTracker(cv::UMat frame)
     {
         TrackerSettings settings;
-        settings.m_distType = tracking::DistJaccard;
+		settings.SetDistances({ 0.0f, 0.0f, 1.0f, 0.0f, 0.0f });
         settings.m_kalmanType = tracking::KalmanUnscented;
         settings.m_filterGoal = tracking::FilterRect;
         settings.m_lostTrackType = tracking::TrackCSRT;       // Use visual objects tracker for collisions resolving
@@ -271,7 +271,7 @@ protected:
     bool InitTracker(cv::UMat frame)
     {
         TrackerSettings settings;
-        settings.m_distType = tracking::DistRects;
+		settings.SetDistances({ 0.0f, 1.0f, 0.0f, 0.0f, 0.0f });
         settings.m_kalmanType = tracking::KalmanLinear;
         settings.m_filterGoal = tracking::FilterRect;
         settings.m_lostTrackType = tracking::TrackCSRT;       // Use visual objects tracker for collisions resolving
@@ -368,7 +368,7 @@ protected:
     bool InitTracker(cv::UMat frame)
     {
         TrackerSettings settings;
-        settings.m_distType = tracking::DistRects;
+		settings.SetDistances({ 0.0f, 1.0f, 0.0f, 0.0f, 0.0f });
         settings.m_kalmanType = tracking::KalmanLinear;
         settings.m_filterGoal = tracking::FilterRect;
         settings.m_lostTrackType = tracking::TrackCSRT;       // Use visual objects tracker for collisions resolving
@@ -423,15 +423,6 @@ protected:
         }
 
         m_detector->CalcMotionMap(frame);
-    }
-
-    ///
-    /// \brief GrayProcessing
-    /// \return
-    ///
-    bool GrayProcessing() const
-    {
-        return false;
     }
 };
 
@@ -501,7 +492,7 @@ protected:
     bool InitTracker(cv::UMat frame)
     {
         TrackerSettings settings;
-        settings.m_distType = tracking::DistRects;
+		settings.SetDistances({ 0.0f, 1.0f, 0.0f, 0.0f, 0.0f });
         settings.m_kalmanType = tracking::KalmanLinear;
         settings.m_filterGoal = tracking::FilterRect;
         settings.m_lostTrackType = tracking::TrackCSRT;       // Use visual objects tracker for collisions resolving
@@ -556,15 +547,6 @@ protected:
         }
 
         m_detector->CalcMotionMap(frame);
-    }
-
-    ///
-    /// \brief GrayProcessing
-    /// \return
-    ///
-    bool GrayProcessing() const
-    {
-        return false;
     }
 };
 
@@ -634,7 +616,7 @@ protected:
     bool InitTracker(cv::UMat frame)
 	{
 		TrackerSettings settings;
-		settings.m_distType = tracking::DistRects;
+		settings.SetDistances({ 0.0f, 1.0f, 0.0f, 0.0f, 0.0f });
 		settings.m_kalmanType = tracking::KalmanLinear;
 		settings.m_filterGoal = tracking::FilterRect;
         settings.m_lostTrackType = tracking::TrackKCF;       // Use visual objects tracker for collisions resolving
@@ -689,15 +671,6 @@ protected:
 		}
 
 		m_detector->CalcMotionMap(frame);
-	}
-
-	///
-	/// \brief GrayProcessing
-	/// \return
-	///
-	bool GrayProcessing() const
-	{
-		return false;
 	}
 };
 

--- a/example/examples.h
+++ b/example/examples.h
@@ -60,14 +60,14 @@ protected:
     bool InitTracker(cv::UMat frame)
     {
         TrackerSettings settings;
-		settings.SetDistances({ 0.0f, 0.0f, 0.5f, 0.5f, 0.0f });
+		settings.SetDistances({ 0.0f, 0.0f, 1.0f, 0.0f, 0.0f });
         settings.m_kalmanType = tracking::KalmanLinear;
         settings.m_filterGoal = tracking::FilterRect;
-        settings.m_lostTrackType = tracking::TrackNone;       // Use visual objects tracker for collisions resolving
+        settings.m_lostTrackType = tracking::TrackKCF;       // Use visual objects tracker for collisions resolving
         settings.m_matchType = tracking::MatchHungrian;
         settings.m_dt = 0.4f;                             // Delta time for Kalman filter
         settings.m_accelNoiseMag = 0.5f;                  // Accel noise magnitude for Kalman filter
-		settings.m_distThres = 0.6; // frame.rows / 10.f;         // Distance threshold between region and object on two frames
+		settings.m_distThres = 0.6f; // frame.rows / 10.f;         // Distance threshold between region and object on two frames
 
         settings.m_useAbandonedDetection = false;
         if (settings.m_useAbandonedDetection)

--- a/src/Detector/BaseDetector.cpp
+++ b/src/Detector/BaseDetector.cpp
@@ -17,7 +17,7 @@
 BaseDetector* CreateDetector(
         tracking::Detectors detectorType,
         const config_t& config,
-        cv::UMat& gray
+        cv::UMat& frame
         )
 {
     BaseDetector* detector = nullptr;
@@ -25,53 +25,53 @@ BaseDetector* CreateDetector(
     switch (detectorType)
     {
     case tracking::Motion_VIBE:
-        detector = new MotionDetector(BackgroundSubtract::BGFG_ALGS::ALG_VIBE, gray);
+        detector = new MotionDetector(BackgroundSubtract::BGFG_ALGS::ALG_VIBE, frame);
         break;
 
     case tracking::Motion_MOG:
-        detector = new MotionDetector(BackgroundSubtract::BGFG_ALGS::ALG_MOG, gray);
+        detector = new MotionDetector(BackgroundSubtract::BGFG_ALGS::ALG_MOG, frame);
         break;
 
     case tracking::Motion_GMG:
-        detector = new MotionDetector(BackgroundSubtract::BGFG_ALGS::ALG_GMG, gray);
+        detector = new MotionDetector(BackgroundSubtract::BGFG_ALGS::ALG_GMG, frame);
         break;
 
     case tracking::Motion_CNT:
-        detector = new MotionDetector(BackgroundSubtract::BGFG_ALGS::ALG_CNT, gray);
+        detector = new MotionDetector(BackgroundSubtract::BGFG_ALGS::ALG_CNT, frame);
         break;
 
     case tracking::Motion_SuBSENSE:
-        detector = new MotionDetector(BackgroundSubtract::BGFG_ALGS::ALG_SuBSENSE, gray);
+        detector = new MotionDetector(BackgroundSubtract::BGFG_ALGS::ALG_SuBSENSE, frame);
         break;
 
     case tracking::Motion_LOBSTER:
-        detector = new MotionDetector(BackgroundSubtract::BGFG_ALGS::ALG_LOBSTER, gray);
+        detector = new MotionDetector(BackgroundSubtract::BGFG_ALGS::ALG_LOBSTER, frame);
         break;
 
     case tracking::Motion_MOG2:
-        detector = new MotionDetector(BackgroundSubtract::BGFG_ALGS::ALG_MOG2, gray);
+        detector = new MotionDetector(BackgroundSubtract::BGFG_ALGS::ALG_MOG2, frame);
         break;
 
     case tracking::Face_HAAR:
-        detector = new FaceDetector(gray);
+        detector = new FaceDetector(frame);
         break;
 
     case tracking::Pedestrian_HOG:
     case tracking::Pedestrian_C4:
-        detector = new PedestrianDetector(gray);
+        detector = new PedestrianDetector(frame);
         break;
 
     case tracking::SSD_MobileNet:
-        detector = new SSDMobileNetDetector(gray);
+        detector = new SSDMobileNetDetector(frame);
         break;
 
     case tracking::Yolo_OCV:
-        detector = new YoloOCVDetector(gray);
+        detector = new YoloOCVDetector(frame);
         break;
 
 	case tracking::Yolo_Darknet:
 #ifdef BUILD_YOLO_LIB
-        detector = new YoloDarknetDetector(gray);
+        detector = new YoloDarknetDetector(frame);
 #else
 		std::cerr << "Darknet inference engine was not configured in CMake" << std::endl;
 #endif

--- a/src/Detector/BaseDetector.h
+++ b/src/Detector/BaseDetector.h
@@ -37,6 +37,11 @@ public:
     ///
     virtual void Detect(cv::UMat& frame) = 0;
 
+	///
+	/// \brief CanGrayProcessing
+	///
+	virtual bool CanGrayProcessing() const = 0;
+
     ///
     /// \brief SetMinObjectSize
     /// \param minObjectSize

--- a/src/Detector/FaceDetector.h
+++ b/src/Detector/FaceDetector.h
@@ -15,6 +15,11 @@ public:
 
     void Detect(cv::UMat& gray);
 
+	bool CanGrayProcessing() const
+	{
+		return true;
+	}
+
 private:
     cv::CascadeClassifier m_cascade;
 };

--- a/src/Detector/MotionDetector.h
+++ b/src/Detector/MotionDetector.h
@@ -16,6 +16,11 @@ public:
 
     void Detect(cv::UMat& gray);
 
+	bool CanGrayProcessing() const
+	{
+		return true;
+	}
+
 	void CalcMotionMap(cv::Mat frame);
 
 private:

--- a/src/Detector/PedestrianDetector.h
+++ b/src/Detector/PedestrianDetector.h
@@ -22,6 +22,11 @@ public:
 
     void Detect(cv::UMat& gray);
 
+	bool CanGrayProcessing() const
+	{
+		return true;
+	}
+
 private:
     DetectorTypes m_detectorType;
 

--- a/src/Detector/SSDMobileNetDetector.h
+++ b/src/Detector/SSDMobileNetDetector.h
@@ -22,6 +22,11 @@ public:
 
     void Detect(cv::UMat& colorFrame);
 
+	bool CanGrayProcessing() const
+	{
+		return false;
+	}
+
 private:
     cv::dnn::Net m_net;
 

--- a/src/Detector/YoloDarknetDetector.h
+++ b/src/Detector/YoloDarknetDetector.h
@@ -24,6 +24,11 @@ public:
 
 	void Detect(cv::UMat& colorFrame);
 
+	bool CanGrayProcessing() const
+	{
+		return false;
+	}
+
 private:
 	std::unique_ptr<Detector> m_detector;
 

--- a/src/Detector/YoloDetector.h
+++ b/src/Detector/YoloDetector.h
@@ -23,6 +23,11 @@ public:
 
     void Detect(cv::UMat& colorFrame);
 
+	bool CanGrayProcessing() const
+	{
+		return false;
+	}
+
 private:
     cv::dnn::Net m_net;
 

--- a/src/Tracker/Ctracker.h
+++ b/src/Tracker/Ctracker.h
@@ -124,10 +124,10 @@ public:
     void Update(const regions_t& regions, cv::UMat currFrame, float fps);
 
     ///
-    /// \brief GrayFrameToTrack
+    /// \brief CanGrayFrameToTrack
     /// \return
     ///
-    bool GrayFrameToTrack() const
+    bool CanGrayFrameToTrack() const
     {
 		bool needColor = (m_settings.m_lostTrackType == tracking::LostTrackType::TrackGOTURN) ||
 			(m_settings.m_lostTrackType == tracking::LostTrackType::TrackDAT) ||
@@ -135,6 +135,15 @@ public:
             (m_settings.m_lostTrackType == tracking::LostTrackType::TrackLDES);
         return !needColor;
     }
+
+	///
+	/// \brief CanColorFrameToTrack
+	/// \return
+	///
+	bool CanColorFrameToTrack() const
+	{
+		return true;
+	}
 
     ///
     /// \brief GetTracksCount

--- a/src/Tracker/Ctracker.h
+++ b/src/Tracker/Ctracker.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <array>
 #include <deque>
+#include <numeric>
 
 #include "defines.h"
 #include "track.h"
@@ -16,11 +17,13 @@
 ///
 struct TrackerSettings
 {
-    tracking::DistType m_distType = tracking::DistCenters;
+    //tracking::DistType m_distType = tracking::DistCenters;
     tracking::KalmanType m_kalmanType = tracking::KalmanLinear;
     tracking::FilterGoal m_filterGoal = tracking::FilterCenter;
     tracking::LostTrackType m_lostTrackType = tracking::TrackKCF;
     tracking::MatchType m_matchType = tracking::MatchHungrian;
+
+	std::array<track_t, tracking::DistsCount> m_distType;
 
     ///
     /// \brief m_dt
@@ -38,7 +41,7 @@ struct TrackerSettings
     /// \brief m_distThres
     /// Distance threshold for Assignment problem for tracking::DistCenters or for tracking::DistRects (for tracking::DistJaccard it need from 0 to 1)
     ///
-    track_t m_distThres = 50;
+    track_t m_distThres = 0.5f;
 
     ///
     /// \brief m_maximumAllowedSkippedFrames
@@ -68,6 +71,40 @@ struct TrackerSettings
     /// After this time (in seconds) the abandoned object will be removed
     ///
     int m_maxStaticTime = 25;
+
+	///
+	TrackerSettings()
+	{
+		m_distType[tracking::DistCenters] = 0.0f;
+		m_distType[tracking::DistRects] = 0.0f;
+		m_distType[tracking::DistJaccard] = 0.5f;
+		m_distType[tracking::DistHist] = 0.5f;
+		m_distType[tracking::DistHOG] = 0.0f;
+
+		assert(CheckDistance());
+	}
+
+	///
+	bool CheckDistance() const
+	{
+		track_t sum = std::accumulate(m_distType.begin(), m_distType.end(), 0.0f);
+		track_t maxOne = std::max(1.0f, std::fabs(sum));
+		return std::fabs(sum - 1.0f) <= std::numeric_limits<track_t>::epsilon() * maxOne;
+	}
+
+	///
+	bool SetDistances(std::array<track_t, tracking::DistsCount> distType)
+	{
+		bool res = true;
+		auto oldDists = m_distType;
+		m_distType = distType;
+		if (!CheckDistance())
+		{
+			m_distType = oldDists;
+			res = false;
+		}
+		return res;
+	}
 };
 
 ///
@@ -77,9 +114,14 @@ class CTracker
 {
 public:
     CTracker(const TrackerSettings& settings);
+	CTracker(const CTracker&) = delete;
+	CTracker(CTracker&&) = delete;
+	CTracker& operator=(const CTracker&) = delete;
+	CTracker& operator=(CTracker&&) = delete;
+	
 	~CTracker(void);
 
-    void Update(const regions_t& regions, cv::UMat grayFrame, float fps);
+    void Update(const regions_t& regions, cv::UMat currFrame, float fps);
 
     ///
     /// \brief GrayFrameToTrack
@@ -129,10 +171,10 @@ private:
 
     cv::UMat m_prevFrame;
 
-    void CreateDistaceMatrix(const regions_t& regions, distMatrix_t& costMatrix, track_t maxPossibleCost, track_t& maxCost);
+    void CreateDistaceMatrix(const regions_t& regions, distMatrix_t& costMatrix, track_t maxPossibleCost, track_t& maxCost, cv::UMat currFrame);
 
     void SolveHungrian(const distMatrix_t& costMatrix, size_t N, size_t M, assignments_t& assignment);
     void SolveBipartiteGraphs(const distMatrix_t& costMatrix, size_t N, size_t M, assignments_t& assignment, track_t maxCost);
 
-    void UpdateTrackingState(const regions_t& regions, cv::UMat grayFrame, float fps);
+    void UpdateTrackingState(const regions_t& regions, cv::UMat currFrame, float fps);
 };

--- a/src/Tracker/HungarianAlg/HungarianAlg.cpp
+++ b/src/Tracker/HungarianAlg/HungarianAlg.cpp
@@ -546,11 +546,11 @@ void AssignmentProblemSolver::assignmentsuboptimal1(assignments_t& assignment, t
 
 					if (singleValidationFound)
 					{
-						for (size_t row = 0; row < nOfRows; row++)
-							if ((nOfValidObservations[row] > 1) && distMatrix[row + nOfRows*col] != std::numeric_limits<track_t>::max())
+						for (size_t nestedRow = 0; nestedRow < nOfRows; nestedRow++)
+							if ((nOfValidObservations[nestedRow] > 1) && distMatrix[nestedRow + nOfRows*col] != std::numeric_limits<track_t>::max())
 							{
-								distMatrix[row + nOfRows*col] = std::numeric_limits<track_t>::max();
-								nOfValidObservations[row] -= 1;
+								distMatrix[nestedRow + nOfRows*col] = std::numeric_limits<track_t>::max();
+								nOfValidObservations[nestedRow] -= 1;
 								nOfValidTracks[col] -= 1;
 								repeatSteps = true;
 							}

--- a/src/Tracker/track.h
+++ b/src/Tracker/track.h
@@ -240,24 +240,39 @@ public:
     ///
     /// \brief CalcDist
     /// Euclidean distance in pixels between objects centres on two N and N+1 frames
-    /// \param pt
+    /// \param reg
     /// \return
     ///
-    track_t CalcDist(const Point_t& pt) const;
+    track_t CalcDistCenter(const CRegion& reg) const;
     ///
     /// \brief CalcDist
     /// Euclidean distance in pixels between object contours on two N and N+1 frames
-    /// \param r
+    /// \param reg
     /// \return
     ///
-    track_t CalcDist(const CRegion& reg) const;
+    track_t CalcDistRect(const CRegion& reg) const;
     ///
     /// \brief CalcDistJaccard
     /// Jaccard distance from 0 to 1 between object bounding rectangles on two N and N+1 frames
-    /// \param r
+    /// \param reg
     /// \return
     ///
     track_t CalcDistJaccard(const CRegion& reg) const;
+	///
+	/// \brief CalcDistJaccard
+	/// Distance from 0 to 1 between objects histogramms on two N and N+1 frames
+	/// \param reg
+	/// \param currFrame
+	/// \return
+	///
+	track_t CalcDistHist(const CRegion& reg, cv::UMat currFrame) const;
+	///
+	/// \brief CalcDistHOG
+	/// Euclidean distance from 0 to 1 between HOG descriptors on two N and N+1 frames
+	/// \param reg
+	/// \return
+	///
+	track_t CalcDistHOG(const CRegion& reg) const;
 
     bool CheckType(const std::string& type) const;
 
@@ -297,7 +312,7 @@ private:
 
     void RectUpdate(const CRegion& region, bool dataCorrect, cv::UMat prevFrame, cv::UMat currFrame);
 
-    void CreateExternalTracker();
+    void CreateExternalTracker(int channels);
 
     void PointUpdate(const Point_t& pt, const cv::Size& newObjSize, bool dataCorrect, const cv::Size& frameSize);
 

--- a/src/defines.h
+++ b/src/defines.h
@@ -106,9 +106,12 @@ enum Detectors
 ///
 enum DistType
 {
-    DistCenters = 0,
-    DistRects = 1,
-    DistJaccard = 2
+    DistCenters,   // Euclidean distance between centers, pixels
+    DistRects,     // Euclidean distance between bounding rectangles, pixels
+    DistJaccard,   // Intersection over Union, IoU, [0, 1]
+	DistHist,      // Bhatacharia distance between histograms, [0, 1]
+	DistHOG,       // Euclidean distance between HOG descriptors, [0, 1]
+	DistsCount
 };
 
 ///
@@ -116,8 +119,8 @@ enum DistType
 ///
 enum FilterGoal
 {
-    FilterCenter = 0,
-    FilterRect = 1
+    FilterCenter,
+    FilterRect
 };
 
 ///
@@ -125,8 +128,8 @@ enum FilterGoal
 ///
 enum KalmanType
 {
-    KalmanLinear = 0,
-    KalmanUnscented = 1,
+    KalmanLinear,
+    KalmanUnscented,
     KalmanAugmentedUnscented
 };
 
@@ -135,8 +138,8 @@ enum KalmanType
 ///
 enum MatchType
 {
-    MatchHungrian = 0,
-    MatchBipart = 1
+    MatchHungrian,
+    MatchBipart
 };
 
 ///
@@ -144,8 +147,8 @@ enum MatchType
 ///
 enum LostTrackType
 {
-    TrackNone = 0,
-    TrackKCF = 1,
+    TrackNone,
+    TrackKCF,
     TrackMIL,
     TrackMedianFlow,
     TrackGOTURN,

--- a/src/defines.h
+++ b/src/defines.h
@@ -53,6 +53,8 @@ public:
     std::string m_type;
     float m_confidence = -1;
 
+	mutable cv::Mat m_hist;
+
 private:
     ///
     /// \brief R2BRect


### PR DESCRIPTION
1. A some detectors (as neural networks) likes color RGB frames. I remove to gray conversion by default and now all detectors and tracking works with RGB frames. But with gray they can work too.

2. An experimental feature: added a complex distance between detection and tracking object: it can use a linear distance, for example D = w1 * IoU + w2 * histDist