### PR TITLE
New OpenCV 4.5.1 tracking API ready

### DIFF
--- a/src/Detector/tensorrt_yolo/CMakeLists.txt
+++ b/src/Detector/tensorrt_yolo/CMakeLists.txt
@@ -38,13 +38,11 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode arch=compute_75,code=compute_
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 find_package(CUDNN REQUIRED)
 find_package(TensorRT REQUIRED)
-find_package(gflags REQUIRED)
 
 include_directories(${OpenCV_INCLUDE_DIRS})
 include_directories(${CUDA_INCLUDE_DIRS})
 include_directories(${CUDNN_INCLUDE_DIR})
 include_directories(${TensorRT_INCLUDE_DIRS})
-include_directories(${GFLAGS_INCLUDE_DIR})
 
 file(GLOB TENSORRT_SOURCE_FILES *.cpp)
 file(GLOB TENSORRT_HEADER_FILES *.h)
@@ -71,7 +69,6 @@ set(TENSORRT_LIBS
     ${CUDNN_LIBRARY}
     # ${LIB_PTHREAD}
     ${TensorRT_LIBRARIES}
-    ${GFLAGS_LIBRARIES}
 )
 
 if (CMAKE_COMPILER_IS_GNUCXX)

--- a/src/Tracker/Kalman.cpp
+++ b/src/Tracker/Kalman.cpp
@@ -2,6 +2,12 @@
 #include <iostream>
 #include <vector>
 
+#if (((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR < 5)) || ((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR == 5) && (CV_VERSION_REVISION < 1)) || (CV_VERSION_MAJOR == 3))
+namespace kalman = cv::tracking;
+#else
+namespace kalman = cv::detail::tracking;
+#endif
+
 //---------------------------------------------------------------------------
 TKalmanFilter::TKalmanFilter(
         tracking::KalmanType type,
@@ -272,12 +278,12 @@ void TKalmanFilter::CreateLinearAcceleration(cv::Rect_<track_t> rect0, Point_t r
 
 #ifdef USE_OCV_UKF
 //---------------------------------------------------------------------------
-class AcceleratedModel: public cv::tracking::UkfSystemModel
+class AcceleratedModel: public kalman::UkfSystemModel
 {
 public:
     AcceleratedModel(track_t deltaTime, bool rectModel)
         :
-          cv::tracking::UkfSystemModel(),
+          kalman::UkfSystemModel(),
           m_deltaTime(deltaTime),
           m_rectModel(rectModel)
     {
@@ -365,7 +371,7 @@ void TKalmanFilter::CreateUnscented(Point_t xy0, Point_t xyv0)
     cv::Mat P = 1e-6f * cv::Mat::eye(DP, DP, Mat_t(1));
 
     cv::Ptr<AcceleratedModel> model(new AcceleratedModel(m_deltaTime, false));
-    cv::tracking::UnscentedKalmanFilterParams params(DP, MP, CP, 0, 0, model);
+    kalman::UnscentedKalmanFilterParams params(DP, MP, CP, 0, 0, model);
     params.dataType = Mat_t(1);
     params.stateInit = initState.clone();
     params.errorCovInit = P.clone();
@@ -376,7 +382,7 @@ void TKalmanFilter::CreateUnscented(Point_t xy0, Point_t xyv0)
     params.beta = 2.0;
     params.k = -2.0;
 
-    m_uncsentedKalman = cv::tracking::createUnscentedKalmanFilter(params);
+    m_uncsentedKalman = kalman::createUnscentedKalmanFilter(params);
 
     m_initialized = true;
 }
@@ -417,7 +423,7 @@ void TKalmanFilter::CreateUnscented(cv::Rect_<track_t> rect0, Point_t rectv0)
     cv::Mat P = 1e-3f * cv::Mat::eye(DP, DP, Mat_t(1));
 
     cv::Ptr<AcceleratedModel> model(new AcceleratedModel(m_deltaTime, true));
-    cv::tracking::UnscentedKalmanFilterParams params(DP, MP, CP, 0, 0, model);
+    kalman::UnscentedKalmanFilterParams params(DP, MP, CP, 0, 0, model);
     params.dataType = Mat_t(1);
     params.stateInit = initState.clone();
     params.errorCovInit = P.clone();
@@ -428,7 +434,7 @@ void TKalmanFilter::CreateUnscented(cv::Rect_<track_t> rect0, Point_t rectv0)
     params.beta = 2.0;
     params.k = -2.0;
 
-    m_uncsentedKalman = cv::tracking::createUnscentedKalmanFilter(params);
+    m_uncsentedKalman = kalman::createUnscentedKalmanFilter(params);
 
     m_initialized = true;
 }
@@ -463,7 +469,7 @@ void TKalmanFilter::CreateAugmentedUnscented(Point_t xy0, Point_t xyv0)
     cv::Mat P = 1e-6f * cv::Mat::eye(DP, DP, Mat_t(1));
 
     cv::Ptr<AcceleratedModel> model(new AcceleratedModel(m_deltaTime, false));
-    cv::tracking::AugmentedUnscentedKalmanFilterParams params(DP, MP, CP, 0, 0, model);
+    kalman::AugmentedUnscentedKalmanFilterParams params(DP, MP, CP, 0, 0, model);
     params.dataType = Mat_t(1);
     params.stateInit = initState.clone();
     params.errorCovInit = P.clone();
@@ -474,7 +480,7 @@ void TKalmanFilter::CreateAugmentedUnscented(Point_t xy0, Point_t xyv0)
     params.beta = 2.0;
     params.k = -2.0;
 
-    m_uncsentedKalman = cv::tracking::createAugmentedUnscentedKalmanFilter(params);
+    m_uncsentedKalman = kalman::createAugmentedUnscentedKalmanFilter(params);
 
     m_initialized = true;
 }
@@ -515,7 +521,7 @@ void TKalmanFilter::CreateAugmentedUnscented(cv::Rect_<track_t> rect0, Point_t r
     cv::Mat P = 1e-3f * cv::Mat::eye(DP, DP, Mat_t(1));
 
     cv::Ptr<AcceleratedModel> model(new AcceleratedModel(m_deltaTime, true));
-    cv::tracking::AugmentedUnscentedKalmanFilterParams params(DP, MP, CP, 0, 0, model);
+    kalman::AugmentedUnscentedKalmanFilterParams params(DP, MP, CP, 0, 0, model);
     params.dataType = Mat_t(1);
     params.stateInit = initState.clone();
     params.errorCovInit = P.clone();
@@ -526,7 +532,7 @@ void TKalmanFilter::CreateAugmentedUnscented(cv::Rect_<track_t> rect0, Point_t r
     params.beta = 2.0;
     params.k = -2.0;
 
-    m_uncsentedKalman = cv::tracking::createAugmentedUnscentedKalmanFilter(params);
+    m_uncsentedKalman = kalman::createAugmentedUnscentedKalmanFilter(params);
 
     m_initialized = true;
 }

--- a/src/Tracker/Kalman.cpp
+++ b/src/Tracker/Kalman.cpp
@@ -2,10 +2,12 @@
 #include <iostream>
 #include <vector>
 
+#ifdef USE_OCV_UKF
 #if (((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR < 5)) || ((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR == 5) && (CV_VERSION_REVISION < 1)) || (CV_VERSION_MAJOR == 3))
 namespace kalman = cv::tracking;
 #else
 namespace kalman = cv::detail::tracking;
+#endif
 #endif
 
 //---------------------------------------------------------------------------

--- a/src/Tracker/Kalman.h
+++ b/src/Tracker/Kalman.h
@@ -31,7 +31,11 @@ public:
 private:
     cv::KalmanFilter m_linearKalman;
 #ifdef USE_OCV_UKF
+#if (((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR < 5)) || ((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR == 5) && (CV_VERSION_REVISION < 1)) || (CV_VERSION_MAJOR == 3))
     cv::Ptr<cv::tracking::UnscentedKalmanFilter> m_uncsentedKalman;
+#else
+    cv::Ptr<cv::detail::tracking::UnscentedKalmanFilter> m_uncsentedKalman;
+#endif
 #endif
 
     static constexpr size_t MIN_INIT_VALS = 4;

--- a/src/Tracker/track.cpp
+++ b/src/Tracker/track.cpp
@@ -602,9 +602,9 @@ void CTrack::RectUpdate(const CRegion& region,
 #endif
 
 #if (((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR < 5)) || ((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR == 5) && (CV_VERSION_REVISION < 1)) || (CV_VERSION_MAJOR == 3))
-				cv::Rect prect(cvRound(newRect.x) + roiRect.x, cvRound(newRect.y) + roiRect.y, cvRound(newRect.width), cvRound(newRect.height));
+                cv::Rect prect(cvRound(newRect.x) + roiRect.x, cvRound(newRect.y) + roiRect.y, cvRound(newRect.width), cvRound(newRect.height));
 #else
-				cv::Rect prect(newRect.x + roiRect.x, newRect.y + roiRect.y, newRect.width, newRect.height);
+                cv::Rect prect(newRect.x + roiRect.x, newRect.y + roiRect.y, newRect.width, newRect.height);
 #endif
 
                 UpdateRRect(brect, m_kalman.Update(prect, true));

--- a/src/Tracker/track.cpp
+++ b/src/Tracker/track.cpp
@@ -586,7 +586,11 @@ void CTrack::RectUpdate(const CRegion& region,
                     m_outOfTheFrame = true;
                 }
             }
+#if (((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR < 5)) || ((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR == 5) && (CV_VERSION_REVISION < 1)) || (CV_VERSION_MAJOR == 3))
             cv::Rect2d newRect;
+#else
+            cv::Rect newRect;
+#endif
             if (!inited && !m_tracker.empty() && m_tracker->update(cv::UMat(currFrame, roiRect), newRect))
             {
 #if 0
@@ -597,7 +601,11 @@ void CTrack::RectUpdate(const CRegion& region,
 #endif
 #endif
 
-                cv::Rect prect(cvRound(newRect.x) + roiRect.x, cvRound(newRect.y) + roiRect.y, cvRound(newRect.width), cvRound(newRect.height));
+#if (((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR < 5)) || ((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR == 5) && (CV_VERSION_REVISION < 1)) || (CV_VERSION_MAJOR == 3))
+				cv::Rect prect(cvRound(newRect.x) + roiRect.x, cvRound(newRect.y) + roiRect.y, cvRound(newRect.width), cvRound(newRect.height));
+#else
+				cv::Rect prect(newRect.x + roiRect.x, newRect.y + roiRect.y, newRect.width, newRect.height);
+#endif
 
                 UpdateRRect(brect, m_kalman.Update(prect, true));
 
@@ -773,12 +781,17 @@ void CTrack::CreateExternalTracker(int channels)
 #ifdef USE_OCV_KCF
         if (!m_tracker || m_tracker.empty())
         {
+#if (((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR > 4)) || (CV_VERSION_MAJOR > 4))
+            std::cerr << "TrackMedianFlow not supported in OpenCV 4.5 and newer!" << std::endl;
+            CV_Assert(0);
+#else
             cv::TrackerMedianFlow::Params params;
 
 #if (((CV_VERSION_MAJOR == 3) && (CV_VERSION_MINOR >= 3)) || (CV_VERSION_MAJOR > 3))
             m_tracker = cv::TrackerMedianFlow::create(params);
 #else
             m_tracker = cv::TrackerMedianFlow::createTracker(params);
+#endif
 #endif
         }
 #endif
@@ -807,10 +820,15 @@ void CTrack::CreateExternalTracker(int channels)
 #ifdef USE_OCV_KCF
         if (!m_tracker || m_tracker.empty())
         {
+#if (((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR > 4)) || (CV_VERSION_MAJOR > 4))
+            std::cerr << "TrackMOSSE not supported in OpenCV 4.5 and newer!" << std::endl;
+            CV_Assert(0);
+#else
 #if (((CV_VERSION_MAJOR == 3) && (CV_VERSION_MINOR > 3)) || (CV_VERSION_MAJOR > 3))
             m_tracker = cv::TrackerMOSSE::create();
 #else
             m_tracker = cv::TrackerMOSSE::createTracker();
+#endif
 #endif
         }
 #endif


### PR DESCRIPTION
1. Some tracking algorithms (MedianFlow and MOSSE now are legacy and removed for OpenCV 4.5.1)
2. Changed namespace for Unscented Kalman filter
3. Removed unused dependence - gflags