### PR TITLE
First reidentification implementation

### DIFF
--- a/example/examples.h
+++ b/example/examples.h
@@ -680,18 +680,19 @@ protected:
 				std::string pathToModel = "../data/";
 #endif
 				pathToModel = "C:/work/home/mtracker/Multitarget-tracker/data/";
+
+				m_trackerSettings.m_embeddings.emplace_back(pathToModel + "open_model_zoo/person-reidentification-retail-0286/FP16-INT8/person-reidentification-retail-0286.xml",
+                                                            pathToModel + "open_model_zoo/person-reidentification-retail-0286/FP16-INT8/person-reidentification-retail-0286.bin",
+                                                            cv::Size(128, 256),
+					                                        std::vector<ObjectTypes>{ ObjectTypes::obj_person });
+
 #if 0
-				m_trackerSettings.m_embeddingCfgName = ""; // pathToModel + "111.meta";
-				m_trackerSettings.m_embeddingWeightsName = pathToModel + "mars-small128_1.pb";
-#else
-#if 0
-				m_trackerSettings.m_embeddingCfgName = "";
-				m_trackerSettings.m_embeddingWeightsName = pathToModel + "open_model_zoo/vehicle-reid-0001/osnet_ain_x1_0_vehicle_reid.onnx";
-#else
-				m_trackerSettings.m_embeddingCfgName = pathToModel + "open_model_zoo/person-reidentification-retail-0286/FP32/person-reidentification-retail-0286.xml";
-				m_trackerSettings.m_embeddingWeightsName = pathToModel + "open_model_zoo/person-reidentification-retail-0286/FP32/person-reidentification-retail-0286.bin";
+				m_trackerSettings.m_embeddings.emplace_back("",
+                                                            pathToModel + "open_model_zoo/vehicle-reid-0001/osnet_ain_x1_0_vehicle_reid.onnx",
+                                                            cv::Size(208, 208),
+                                                            std::vector<ObjectTypes>{ ObjectTypes::obj_car, ObjectTypes::obj_bus, ObjectTypes::obj_truck });
 #endif
-#endif
+
 				std::array<track_t, tracking::DistsCount> distType{
 					0.f,   // DistCenters
 					0.f,   // DistRects
@@ -709,7 +710,7 @@ protected:
 
 			m_trackerSettings.m_kalmanType = tracking::KalmanLinear;
 			m_trackerSettings.m_filterGoal = tracking::FilterRect;
-			m_trackerSettings.m_lostTrackType = tracking::TrackCSRT;      // Use visual objects tracker for collisions resolving. Used if m_filterGoal == tracking::FilterRect
+			m_trackerSettings.m_lostTrackType = useDeepSORT ? tracking::TrackNone : tracking::TrackCSRT; // Use visual objects tracker for collisions resolving. Used if m_filterGoal == tracking::FilterRect
 			m_trackerSettings.m_matchType = tracking::MatchHungrian;
 			m_trackerSettings.m_useAcceleration = false;                   // Use constant acceleration motion model
 			m_trackerSettings.m_dt = m_trackerSettings.m_useAcceleration ? 0.05f : 0.4f; // Delta time for Kalman filter

--- a/example/examples.h
+++ b/example/examples.h
@@ -670,7 +670,43 @@ protected:
 	{
 		if (!m_trackerSettingsLoaded)
 		{
-			m_trackerSettings.SetDistance(tracking::DistCenters);
+			bool useDeepSORT = false;
+
+			if (useDeepSORT)
+			{
+#ifdef _WIN32
+				std::string pathToModel = "../../data/";
+#else
+				std::string pathToModel = "../data/";
+#endif
+				pathToModel = "C:/work/home/mtracker/Multitarget-tracker/data/";
+#if 0
+				m_trackerSettings.m_embeddingCfgName = ""; // pathToModel + "111.meta";
+				m_trackerSettings.m_embeddingWeightsName = pathToModel + "mars-small128_1.pb";
+#else
+#if 0
+				m_trackerSettings.m_embeddingCfgName = "";
+				m_trackerSettings.m_embeddingWeightsName = pathToModel + "open_model_zoo/vehicle-reid-0001/osnet_ain_x1_0_vehicle_reid.onnx";
+#else
+				m_trackerSettings.m_embeddingCfgName = pathToModel + "open_model_zoo/person-reidentification-retail-0286/FP32/person-reidentification-retail-0286.xml";
+				m_trackerSettings.m_embeddingWeightsName = pathToModel + "open_model_zoo/person-reidentification-retail-0286/FP32/person-reidentification-retail-0286.bin";
+#endif
+#endif
+				std::array<track_t, tracking::DistsCount> distType{
+					0.f,   // DistCenters
+					0.f,   // DistRects
+					0.5f,  // DistJaccard
+					0.f,   // DistHist
+					0.5f   // DistFeatureCos
+				};
+				if (!m_trackerSettings.SetDistances(distType))
+					std::cerr << "SetDistances failed! Absolutly summ must be equal 1" << std::endl;
+			}
+			else
+			{
+				m_trackerSettings.SetDistance(tracking::DistCenters);
+			}
+
 			m_trackerSettings.m_kalmanType = tracking::KalmanLinear;
 			m_trackerSettings.m_filterGoal = tracking::FilterRect;
 			m_trackerSettings.m_lostTrackType = tracking::TrackCSRT;      // Use visual objects tracker for collisions resolving. Used if m_filterGoal == tracking::FilterRect

--- a/example/examples.h
+++ b/example/examples.h
@@ -679,7 +679,6 @@ protected:
 #else
 				std::string pathToModel = "../data/";
 #endif
-				pathToModel = "C:/work/home/mtracker/Multitarget-tracker/data/";
 
 				m_trackerSettings.m_embeddings.emplace_back(pathToModel + "open_model_zoo/person-reidentification-retail-0286/FP16-INT8/person-reidentification-retail-0286.xml",
                                                             pathToModel + "open_model_zoo/person-reidentification-retail-0286/FP16-INT8/person-reidentification-retail-0286.bin",

--- a/src/Tracker/CMakeLists.txt
+++ b/src/Tracker/CMakeLists.txt
@@ -18,6 +18,7 @@ set(main_sources ../common/nms.h ../common/defines.h ../common/object_types.h ..
              HungarianAlg/HungarianAlg.h
 
              VOTTracker.hpp
+             EmbeddingsCalculator.hpp
              dat/dat_tracker.cpp
              dat/dat_tracker.hpp
 )

--- a/src/Tracker/Ctracker.h
+++ b/src/Tracker/Ctracker.h
@@ -11,7 +11,7 @@
 #include "defines.h"
 #include "track.h"
 #include "ShortPathCalculator.h"
-
+#include "EmbeddingsCalculator.hpp"
 // ----------------------------------------------------------------------
 
 ///
@@ -102,6 +102,17 @@ struct TrackerSettings
 	/// Object types that can be matched while tracking
 	///
 	std::map<objtype_t, std::set<objtype_t>> m_nearTypes;
+
+	///
+	/// \brief m_embeddingCfgName
+	/// Neural network config file for embeddings
+	///
+	std::string m_embeddingCfgName;
+	///
+	/// \brief m_embeddingWeightsName
+	/// Neural network weights file for embeddings
+	///
+	std::string m_embeddingWeightsName;
 
 	///
 	TrackerSettings()
@@ -248,6 +259,7 @@ private:
     cv::UMat m_prevFrame;
 
     std::unique_ptr<ShortPathCalculator> m_SPCalculator;
+	EmbeddingsCalculator m_embCalculator;
 
     void CreateDistaceMatrix(const regions_t& regions, std::vector<RegionEmbedding>& regionEmbeddings, distMatrix_t& costMatrix, track_t maxPossibleCost, track_t& maxCost, cv::UMat currFrame);
     void UpdateTrackingState(const regions_t& regions, cv::UMat currFrame, float fps);

--- a/src/Tracker/Ctracker.h
+++ b/src/Tracker/Ctracker.h
@@ -103,16 +103,38 @@ struct TrackerSettings
 	///
 	std::map<objtype_t, std::set<objtype_t>> m_nearTypes;
 
+    ///
+    struct EmbeddingParams
+    {
+        ///
+        /// \brief m_embeddingCfgName
+        /// Neural network config file for embeddings
+        ///
+        std::string m_embeddingCfgName;
+        ///
+        /// \brief m_embeddingWeightsName
+        /// Neural network weights file for embeddings
+        ///
+        std::string m_embeddingWeightsName;
+
+		///
+		cv::Size m_inputLayer{128, 256};
+
+		///
+		std::vector<ObjectTypes> m_objectTypes;
+
+		EmbeddingParams(const std::string& embeddingCfgName, const std::string& embeddingWeightsName,
+			const cv::Size& inputLayer, const std::vector<ObjectTypes>& objectTypes)
+			: m_embeddingCfgName(embeddingCfgName),
+			m_embeddingWeightsName(embeddingWeightsName),
+			m_inputLayer(inputLayer),
+			m_objectTypes(objectTypes)
+		{
+			assert(!m_objectTypes.empty());
+		}
+    };
 	///
-	/// \brief m_embeddingCfgName
-	/// Neural network config file for embeddings
-	///
-	std::string m_embeddingCfgName;
-	///
-	/// \brief m_embeddingWeightsName
-	/// Neural network weights file for embeddings
-	///
-	std::string m_embeddingWeightsName;
+	std::vector<EmbeddingParams> m_embeddings;
 
 	///
 	TrackerSettings()
@@ -261,7 +283,7 @@ private:
     cv::UMat m_prevFrame;
 
     std::unique_ptr<ShortPathCalculator> m_SPCalculator;
-	EmbeddingsCalculator m_embCalculator;
+	std::map<objtype_t, std::shared_ptr<EmbeddingsCalculator>> m_embCalculators;
 
     void CreateDistaceMatrix(const regions_t& regions, std::vector<RegionEmbedding>& regionEmbeddings, distMatrix_t& costMatrix, track_t maxPossibleCost, track_t& maxCost, cv::UMat currFrame);
     void UpdateTrackingState(const regions_t& regions, cv::UMat currFrame, float fps);

--- a/src/Tracker/Ctracker.h
+++ b/src/Tracker/Ctracker.h
@@ -121,6 +121,7 @@ struct TrackerSettings
 		m_distType[tracking::DistRects] = 0.0f;
 		m_distType[tracking::DistJaccard] = 0.5f;
 		m_distType[tracking::DistHist] = 0.5f;
+		m_distType[tracking::DistFeatureCos] = 0.0f;
 
 		assert(CheckDistance());
 	}
@@ -130,6 +131,7 @@ struct TrackerSettings
 	{
 		track_t sum = std::accumulate(m_distType.begin(), m_distType.end(), 0.0f);
 		track_t maxOne = std::max(1.0f, std::fabs(sum));
+		//std::cout << "CheckDistance: " << sum << " - " << (std::numeric_limits<track_t>::epsilon() * maxOne) << ", " << std::fabs(sum - 1.0f) << std::endl;
 		return std::fabs(sum - 1.0f) <= std::numeric_limits<track_t>::epsilon() * maxOne;
 	}
 

--- a/src/Tracker/EmbeddingsCalculator.hpp
+++ b/src/Tracker/EmbeddingsCalculator.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+///
+/// \brief The EmbeddingsCalculator class
+///
+class EmbeddingsCalculator
+{
+public:
+    EmbeddingsCalculator() = default;
+    virtual ~EmbeddingsCalculator() = default;
+
+	///
+	bool Initialize(const std::string& cfgName, const std::string& weightsName)
+	{
+		m_net = cv::dnn::readNet(weightsName, cfgName);
+		if (!m_net.empty())
+		{
+			m_net.setPreferableBackend(cv::dnn::DNN_BACKEND_DEFAULT);
+			m_net.setPreferableTarget(cv::dnn::DNN_TARGET_CPU);
+		}
+		return !m_net.empty();
+	}
+	
+	///
+	bool IsInitialized() const
+	{
+		return !m_net.empty();
+	}
+
+	///
+	void Calc(const cv::UMat& img, const cv::Rect& rect, cv::Mat& embedding)
+	{
+		cv::UMat obj;
+		cv::resize(img(rect), obj, cv::Size(64, 128), 0., 0., cv::INTER_LINEAR);
+		cv::Mat blob = cv::dnn::blobFromImage(obj, 1.0, cv::Size(), cv::Scalar(), false, false);
+		
+		m_net.setInput(blob);
+		embedding = m_net.forward();
+		std::cout << "embedding: " << embedding.size() << ", chans = " << embedding.channels() << std::endl;
+	}
+
+private:
+	cv::dnn::Net m_net;
+};

--- a/src/Tracker/EmbeddingsCalculator.hpp
+++ b/src/Tracker/EmbeddingsCalculator.hpp
@@ -12,10 +12,14 @@ public:
 	///
 	bool Initialize(const std::string& cfgName, const std::string& weightsName)
 	{
+#if 1
 		m_net = cv::dnn::readNet(weightsName, cfgName);
+#else
+		m_net = cv::dnn::readNetFromTensorflow(weightsName, cfgName);
+#endif
 		if (!m_net.empty())
 		{
-			m_net.setPreferableBackend(cv::dnn::DNN_BACKEND_DEFAULT);
+			m_net.setPreferableBackend(cv::dnn::DNN_BACKEND_INFERENCE_ENGINE);
 			m_net.setPreferableTarget(cv::dnn::DNN_TARGET_CPU);
 		}
 		return !m_net.empty();
@@ -31,7 +35,9 @@ public:
 	void Calc(const cv::UMat& img, const cv::Rect& rect, cv::Mat& embedding)
 	{
 		cv::UMat obj;
-		cv::resize(img(rect), obj, cv::Size(64, 128), 0., 0., cv::INTER_LINEAR);
+		//cv::resize(img(rect), obj, cv::Size(64, 128), 0., 0., cv::INTER_LINEAR); // mars-small128_1.pb
+		cv::resize(img(rect), obj, cv::Size(208, 208), 0., 0., cv::INTER_LINEAR);  // vehicle-reid-0001
+		cv::resize(img(rect), obj, cv::Size(128, 256), 0., 0., cv::INTER_LINEAR);  // person-reidentification-retail-0277
 		cv::Mat blob = cv::dnn::blobFromImage(obj, 1.0, cv::Size(), cv::Scalar(), false, false);
 		
 		m_net.setInput(blob);

--- a/src/Tracker/staple/staple_tracker.cpp
+++ b/src/Tracker/staple/staple_tracker.cpp
@@ -644,7 +644,7 @@ void STAPLE_TRACKER::getFeatureMap(cv::Mat &im_patch, const char* feature_type, 
 
     // out(:,:,1) = single(im_patch)/255 - 0.5;
 
-    float alpha = 1. / 255.0f;
+    float alpha = 1.f / 255.0f;
     float betta = 0.5f;
 
     typedef cv::Vec<float, 28> Vecf28;

--- a/src/Tracker/staple/staple_tracker.hpp
+++ b/src/Tracker/staple/staple_tracker.hpp
@@ -26,7 +26,7 @@ struct staple_cfg
     const char * feature_type = "fhog"; // "fhog", ""gray""
     float inner_padding = 0.2f;         // defines inner area used to sample colors from the foreground
     float output_sigma_factor = 1/16.0f; // standard deviation for the desired translation filter output
-    float lambda = 1e-3;               // egularization weight
+	float lambda = 1e-3f;               // egularization weight
     float learning_rate_cf = 0.01f;     // HOG model learning rate
     float merge_factor = 0.3f;          // fixed interpolation factor - how to linearly combine the two responses
     const char * merge_method = "const_factor";

--- a/src/Tracker/track.cpp
+++ b/src/Tracker/track.cpp
@@ -169,10 +169,10 @@ track_t CTrack::CalcDistHist(const CRegion& reg, RegionEmbedding& embedding, cv:
 
 ///
 /// \brief CTrack::CalcCosine
-/// \param reg
+/// \param embedding
 /// \return
 ///
-track_t CTrack::CalcCosine(const CRegion& reg, RegionEmbedding& embedding, cv::UMat currFrame) const
+track_t CTrack::CalcCosine(RegionEmbedding& embedding, cv::UMat currFrame) const
 {
 	track_t res = 1;
 	if (!embedding.m_embedding.empty() && !m_regionEmbedding.m_embedding.empty())
@@ -560,7 +560,7 @@ void CTrack::RectUpdate(const CRegion& region,
             {
                 CreateExternalTracker(currFrame.channels());
 
-                cv::Rect2d lastRect(brect.x - roiRect.x, brect.y - roiRect.y, brect.width, brect.height);
+                cv::Rect2d lastRect;
                 if (m_staticFrame.empty())
                 {
                     int dx = 1;//m_predictionRect.width / 8;

--- a/src/Tracker/track.h
+++ b/src/Tracker/track.h
@@ -239,8 +239,6 @@ struct TrackingObject
 ///
 struct RegionEmbedding
 {
-	static constexpr size_t EMBEDDING_SIZE = 128;
-
     cv::Mat m_hist;
 	cv::Mat m_embedding;
 	double m_embDot = 0.;

--- a/src/Tracker/track.h
+++ b/src/Tracker/track.h
@@ -302,11 +302,11 @@ public:
 	///
 	/// \brief CalcCosine
 	/// Distance from 0 to 1 between objects embeddings on two N and N+1 frames
-	/// \param reg
+	/// \param embedding
 	/// \param currFrame
 	/// \return
 	///
-	track_t CalcCosine(const CRegion& reg, RegionEmbedding& embedding, cv::UMat currFrame) const;
+	track_t CalcCosine(RegionEmbedding& embedding, cv::UMat currFrame) const;
 
 	cv::RotatedRect CalcPredictionEllipse(cv::Size_<track_t> minRadius) const;
 	///

--- a/src/Tracker/track.h
+++ b/src/Tracker/track.h
@@ -239,7 +239,11 @@ struct TrackingObject
 ///
 struct RegionEmbedding
 {
+	static constexpr size_t EMBEDDING_SIZE = 128;
+
     cv::Mat m_hist;
+	cv::Mat m_embedding;
+	double m_embDot = 0.;
 };
 
 
@@ -269,15 +273,15 @@ public:
            tracking::LostTrackType externalTrackerForLost);
 
     ///
-    /// \brief CalcDist
-    /// Euclidean distance in pixels between objects centres on two N and N+1 frames
+    /// \brief CalcDistCenter
+    /// Euclidean distance from 0 to 1  between objects centres on two N and N+1 frames
     /// \param reg
     /// \return
     ///
     track_t CalcDistCenter(const CRegion& reg) const;
     ///
-    /// \brief CalcDist
-    /// Euclidean distance in pixels between object contours on two N and N+1 frames
+    /// \brief CalcDistRect
+    /// Euclidean distance from 0 to 1 between object contours on two N and N+1 frames
     /// \param reg
     /// \return
     ///
@@ -290,13 +294,21 @@ public:
     ///
     track_t CalcDistJaccard(const CRegion& reg) const;
 	///
-	/// \brief CalcDistJaccard
+	/// \brief CalcDistHist
 	/// Distance from 0 to 1 between objects histogramms on two N and N+1 frames
 	/// \param reg
 	/// \param currFrame
 	/// \return
 	///
-    track_t CalcDistHist(const CRegion& reg, cv::Mat& hist, cv::UMat currFrame) const;
+    track_t CalcDistHist(const CRegion& reg, RegionEmbedding& embedding, cv::UMat currFrame) const;
+	///
+	/// \brief CalcCosine
+	/// Distance from 0 to 1 between objects embeddings on two N and N+1 frames
+	/// \param reg
+	/// \param currFrame
+	/// \return
+	///
+	track_t CalcCosine(const CRegion& reg, RegionEmbedding& embedding, cv::UMat currFrame) const;
 
 	cv::RotatedRect CalcPredictionEllipse(cv::Size_<track_t> minRadius) const;
 	///

--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -107,10 +107,11 @@ enum Detectors
 ///
 enum DistType
 {
-    DistCenters,   // Euclidean distance between centers, pixels
-    DistRects,     // Euclidean distance between bounding rectangles, pixels
-    DistJaccard,   // Intersection over Union, IoU, [0, 1]
-	DistHist,      // Bhatacharia distance between histograms, [0, 1]
+    DistCenters,    // Euclidean distance between centers, [0, 1]
+    DistRects,      // Euclidean distance between bounding rectangles, [0, 1]
+    DistJaccard,    // Intersection over Union, IoU, [0, 1]
+	DistHist,       // Bhatacharia distance between histograms, [0, 1]
+	DistFeatureCos, // Cosine distance between embeddings, [0, 1]
 	DistsCount
 };
 


### PR DESCRIPTION
Added new metric between objects - cosine distance for deep embeddings.
It works now only for opencv_dnn with inference engine backend (OpenVINO). I'm testing with model person-reidentification-retail-0286 from open_model_zoo ( https://github.com/openvinotoolkit/open_model_zoo/tree/master/models/intel/person-reidentification-retail-0286 ). It need to download this model and put it into data folder (or set path to model in examples.h).
I'm tested this approach with Darknet example.