### PR TITLE
Add  option to use or not use OpenCV DNN

### DIFF
--- a/src/Detector/BaseDetector.cpp
+++ b/src/Detector/BaseDetector.cpp
@@ -63,9 +63,11 @@ std::unique_ptr<BaseDetector> CreateDetector(
         detector = std::make_unique<PedestrianDetector>(frame);
         break;
 
+#ifdef USE_OCV_DNN
     case tracking::DNN_OCV:
         detector = std::make_unique<OCVDNNDetector>(frame);
         break;
+#endif
 
 	case tracking::Yolo_Darknet:
 #ifdef BUILD_YOLO_LIB

--- a/src/Detector/CMakeLists.txt
+++ b/src/Detector/CMakeLists.txt
@@ -14,7 +14,7 @@ project(mdetection)
              FaceDetector.cpp
              PedestrianDetector.cpp
              pedestrians/c4-pedestrian-detector.cpp
-             OCVDNNDetector.cpp
+
 
              BaseDetector.h
              MotionDetector.h
@@ -29,7 +29,7 @@ project(mdetection)
              FaceDetector.h
              PedestrianDetector.h
              pedestrians/c4-pedestrian-detector.h
-             OCVDNNDetector.h
+
 )
 
 if (BUILD_YOLO_LIB)
@@ -38,6 +38,12 @@ endif()
 
 if (BUILD_YOLO_TENSORRT)
     set(detector_sources ${detector_sources} YoloTensorRTDetector.cpp YoloTensorRTDetector.h)
+endif()
+
+option(USE_OCV_DNN "Use OpenCV DNN module?" ON)
+if (USE_OCV_DNN)
+    set(detector_sources ${detector_sources} OCVDNNDetector.cpp OCVDNNDetector.h)
+    add_definitions(-DUSE_OCV_DNN)
 endif()
 
   SOURCE_GROUP("Detector" FILES ${detector_sources})
@@ -67,7 +73,7 @@ include_directories(${PROJECT_SOURCE_DIR}/../src)
 include_directories(${PROJECT_SOURCE_DIR}/../common)
 
 if (CMAKE_COMPILER_IS_GNUCXX)
-    add_library(${PROJECT_NAME} SHARED 
+    add_library(${PROJECT_NAME} SHARED
 	${detector_sources})
 else(CMAKE_COMPILER_IS_GNUCXX)
     add_library(${PROJECT_NAME}

--- a/src/Detector/OCVDNNDetector.h
+++ b/src/Detector/OCVDNNDetector.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifdef USE_OCV_DNN
+
 #include "BaseDetector.h"
 
 #include <opencv2/dnn.hpp>
@@ -44,3 +46,5 @@ private:
     std::string m_outLayerType;
     cv::UMat m_inputBlob;
 };
+
+#endif


### PR DESCRIPTION
This adds the option to disable (enabled by default) using the OpenCV DNN module, e.g.
```
$ cmake -DUSE_OCV_EMBEDDINGS=OFF -DUSE_OCV_DNN=OFF
```
In case the DNN module is disabled with OpenCV.