### PR TITLE
Fix CMake distribution install directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,8 +103,8 @@ add_subdirectory(src)
 
 
 # Create CMake config files for distribution
-set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/include/ )
-set(LIB_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/lib/ )
+set(INCLUDE_INSTALL_DIR include/ )
+set(LIB_INSTALL_DIR lib/ )
 
 install(EXPORT MTTrackingExports
     FILE ${PROJECT_NAME}Targets.cmake


### PR DESCRIPTION
Fixing the cmake distribution files (e.g. `MTTrackingTargets.cmake`) to not use absolute install paths rather relative, so the entire package is truly relocatable. With absolute paths - it's not relocatable.