### PR TITLE
Add TrackerDaSiamRPN  as single object visual tracker

### DIFF
--- a/src/Tracker/track.cpp
+++ b/src/Tracker/track.cpp
@@ -598,6 +598,7 @@ void CTrack::RectUpdate(const CRegion& region,
         case tracking::TrackGOTURN:
         case tracking::TrackMOSSE:
         case tracking::TrackCSRT:
+        case tracking::TrackDaSiamRPN:
 #ifdef USE_OCV_KCF
             {
                 roiRect.width = std::max(3 * brect.width, currFrame.cols / 4);
@@ -696,6 +697,7 @@ void CTrack::RectUpdate(const CRegion& region,
     case tracking::TrackGOTURN:
     case tracking::TrackMOSSE:
 	case tracking::TrackCSRT:
+    case tracking::TrackDaSiamRPN:
 #ifdef USE_OCV_KCF
         {
             cv::Rect roiRect;
@@ -982,6 +984,20 @@ void CTrack::CreateExternalTracker(int channels)
 				params.use_rgb = true;
 			}
 			m_tracker = cv::TrackerCSRT::create(params);
+#endif
+		}
+#endif
+        if (m_VOTTracker)
+            m_VOTTracker = nullptr;
+		break;
+        
+    case tracking::TrackDaSiamRPN:
+#ifdef USE_OCV_KCF
+		if (!m_tracker || m_tracker.empty())
+		{
+#if (((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR > 5)) || ((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR == 5) && (CV_VERSION_REVISION > 2))  || (CV_VERSION_MAJOR > 4))
+			cv::TrackerDaSiamRPN::Params params;
+			m_tracker = cv::TrackerDaSiamRPN::create(params);
 #endif
 		}
 #endif

--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -229,6 +229,7 @@ enum LostTrackType
     TrackDAT,
     TrackSTAPLE,
     TrackLDES,
+    TrackDaSiamRPN,
     SingleTracksCount
 };
 }


### PR DESCRIPTION
But it don't work standalone. It needs models and opencv_dnn module:

```
TrackerDaSiamRPN::Params::Params()
{
    model = "dasiamrpn_model.onnx";
    kernel_cls1 = "dasiamrpn_kernel_cls1.onnx";
    kernel_r1 = "dasiamrpn_kernel_r1.onnx";
#ifdef HAVE_OPENCV_DNN
    backend = dnn::DNN_BACKEND_DEFAULT;
    target = dnn::DNN_TARGET_CPU;
#else
    backend = -1;  // invalid value
    target = -1;  // invalid value
#endif
}

```