### PR TITLE
VitTracker and NanoTracker

### DIFF
--- a/src/Tracker/track.cpp
+++ b/src/Tracker/track.cpp
@@ -704,6 +704,8 @@ void CTrack::RectUpdate(const CRegion& region,
         case tracking::TrackMOSSE:
         case tracking::TrackCSRT:
         case tracking::TrackDaSiamRPN:
+        case tracking::TrackNano:
+        case tracking::TrackVit:
 #ifdef USE_OCV_KCF
             {
                 roiRect.width = std::max(3 * brect.width, currFrame.cols / 4);
@@ -803,6 +805,8 @@ void CTrack::RectUpdate(const CRegion& region,
     case tracking::TrackMOSSE:
 	case tracking::TrackCSRT:
     case tracking::TrackDaSiamRPN:
+    case tracking::TrackNano:
+    case tracking::TrackVit:
 #ifdef USE_OCV_KCF
         {
             cv::Rect roiRect;
@@ -1140,6 +1144,39 @@ void CTrack::CreateExternalTracker(int channels)
         if (m_VOTTracker)
             m_VOTTracker = nullptr;
 		break;
+
+    case tracking::TrackNano:
+#ifdef USE_OCV_KCF
+        if (!m_tracker || m_tracker.empty())
+        {
+#if (((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR > 5)) || ((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR == 5) && (CV_VERSION_REVISION > 2))  || (CV_VERSION_MAJOR > 4))
+            cv::TrackerNano::Params params;
+            params.backbone = "nanotrack_backbone_sim.onnx";
+            params.neckhead = "nanotrack_head_sim.onnx";
+            // backend
+            // 0: automatically (by default)
+            // 1: Halide language
+            // 2: Intel's Deep Learning Inference Engine
+            // 3: OpenCV implementation
+            // 4: VKCOM
+            // 5: CUDA
+            params.backend = 0;
+            // target
+            // 0: CPU target (by default)
+            // 1: OpenCL
+            // 2: OpenCL fp16 (half-float precision)
+            // 3: VPU
+            // 4: Vulkan
+            // 6: CUDA
+            // 7: CUDA fp16 (half-float preprocess)
+            params.target = 0;
+            m_tracker = cv::TrackerNano::create(params);
+#endif
+        }
+#endif
+        if (m_VOTTracker)
+            m_VOTTracker = nullptr;
+        break;
 
     case tracking::TrackVit:
 #ifdef USE_OCV_KCF

--- a/src/Tracker/track.cpp
+++ b/src/Tracker/track.cpp
@@ -1113,6 +1113,26 @@ void CTrack::CreateExternalTracker(int channels)
 		{
 #if (((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR > 5)) || ((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR == 5) && (CV_VERSION_REVISION > 2))  || (CV_VERSION_MAJOR > 4))
 			cv::TrackerDaSiamRPN::Params params;
+            params.model = "dasiamrpn_model.onnx";
+            params.kernel_cls1 = "dasiamrpn_kernel_cls1.onnx";
+            params.kernel_r1 = "dasiamrpn_kernel_r1.onnx";
+            // backend
+            // 0: automatically (by default)
+            // 1: Halide language
+            // 2: Intel's Deep Learning Inference Engine
+            // 3: OpenCV implementation
+            // 4: VKCOM
+            // 5: CUDA
+            params.backend = 0;
+            // target
+            // 0: CPU target (by default)
+            // 1: OpenCL
+            // 2: OpenCL fp16 (half-float precision)
+            // 3: VPU
+            // 4: Vulkan
+            // 6: CUDA
+            // 7: CUDA fp16 (half-float preprocess)
+            params.target = 0;
 			m_tracker = cv::TrackerDaSiamRPN::create(params);
 #endif
 		}
@@ -1120,6 +1140,38 @@ void CTrack::CreateExternalTracker(int channels)
         if (m_VOTTracker)
             m_VOTTracker = nullptr;
 		break;
+
+    case tracking::TrackVit:
+#ifdef USE_OCV_KCF
+        if (!m_tracker || m_tracker.empty())
+        {
+#if (((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR > 8)) || (CV_VERSION_MAJOR > 4))
+            cv::TrackerVit::Params params;
+            params.net = "vitTracker.onnx";
+            // backend
+            // 0: automatically (by default)
+            // 1: Halide language
+            // 2: Intel's Deep Learning Inference Engine
+            // 3: OpenCV implementation
+            // 4: VKCOM
+            // 5: CUDA
+            params.backend = 0;
+            // target
+            // 0: CPU target (by default)
+            // 1: OpenCL
+            // 2: OpenCL fp16 (half-float precision)
+            // 3: VPU
+            // 4: Vulkan
+            // 6: CUDA
+            // 7: CUDA fp16 (half-float preprocess)
+            params.target = 0;
+            m_tracker = cv::TrackerVit::create(params);
+#endif
+        }
+#endif
+        if (m_VOTTracker)
+            m_VOTTracker = nullptr;
+        break;
 
     case tracking::TrackDAT:
 #ifdef USE_OCV_KCF

--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -427,6 +427,7 @@ enum LostTrackType
     TrackSTAPLE,
     TrackLDES,
     TrackDaSiamRPN,
+    TrackVit,
     SingleTracksCount
 };
 }

--- a/src/common/defines.h
+++ b/src/common/defines.h
@@ -427,6 +427,7 @@ enum LostTrackType
     TrackSTAPLE,
     TrackLDES,
     TrackDaSiamRPN,
+    TrackNano,
     TrackVit,
     SingleTracksCount
 };


### PR DESCRIPTION
Added 2 new trackers from OpenCV 4.8 and 4.9. They can be used as visual trackers for lost objects.