### PR TITLE
Fix yolov8 instance segmentation

### DIFF
--- a/src/Detector/tensorrt_yolo/YoloONNX.cpp
+++ b/src/Detector/tensorrt_yolo/YoloONNX.cpp
@@ -654,6 +654,9 @@ void YoloONNX::ProcessMaskOutput(size_t imgIdx, const std::vector<float*>& outpu
 
                 std::vector<float> temp_proto(output + k + 5 + nc, output + k + net_width);
                 picked_proposals.push_back(temp_proto);
+
+                if (rectBoxes.size() >= CV_CN_MAX - 1)
+                    break;
             }
         }
 

--- a/src/Tracker/track.cpp
+++ b/src/Tracker/track.cpp
@@ -1149,7 +1149,7 @@ void CTrack::CreateExternalTracker(int channels)
 #ifdef USE_OCV_KCF
         if (!m_tracker || m_tracker.empty())
         {
-#if (((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR > 5)) || ((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR == 5) && (CV_VERSION_REVISION > 2))  || (CV_VERSION_MAJOR > 4))
+#if (((CV_VERSION_MAJOR == 4) && (CV_VERSION_MINOR > 6)) || (CV_VERSION_MAJOR > 4))
             cv::TrackerNano::Params params;
             params.backbone = "nanotrack_backbone_sim.onnx";
             params.neckhead = "nanotrack_head_sim.onnx";


### PR DESCRIPTION
This bug for objects count more than 512 (CV_CN_MAX)